### PR TITLE
Add delete support

### DIFF
--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -109,3 +109,24 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("expected age 35, got %v", row["age"])
 	}
 }
+
+func TestDelete(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	res, err := db.Table("users").Where("name", "alice").Delete()
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if aff, err := res.RowsAffected(); err != nil {
+		t.Fatalf("rows affected: %v", err)
+	} else if aff != 1 {
+		t.Errorf("expected 1 row affected, got %d", aff)
+	}
+
+	var row map[string]any
+	err = db.Table("users").Where("name", "alice").FirstMap(&row)
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected ErrNoRows, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- support DELETE queries in `orm/query`
- add `copyBuilderStateDelete` helper to copy clauses
- test DELETE behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852f21c96e48328a79efa2e2298a091