### PR TITLE
Add select query tests

### DIFF
--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -29,13 +29,25 @@ func setupDB(t testing.TB) *orm.DB {
 	if err != nil {
 		t.Fatalf("create table: %v", err)
 	}
+	_, err = stdDB.Exec(`CREATE TABLE IF NOT EXISTS profiles (id INT AUTO_INCREMENT PRIMARY KEY, user_id INT, bio VARCHAR(255))`)
+	if err != nil {
+		t.Fatalf("create profiles table: %v", err)
+	}
 	_, err = stdDB.Exec("TRUNCATE TABLE users")
 	if err != nil {
 		t.Fatalf("truncate table: %v", err)
 	}
+	_, err = stdDB.Exec("TRUNCATE TABLE profiles")
+	if err != nil {
+		t.Fatalf("truncate profiles: %v", err)
+	}
 	_, err = stdDB.Exec("INSERT INTO users(name, age) VALUES ('alice', 30), ('bob', 25)")
 	if err != nil {
-		t.Fatalf("insert: %v", err)
+		t.Fatalf("insert users: %v", err)
+	}
+	_, err = stdDB.Exec("INSERT INTO profiles(user_id, bio) VALUES (1, 'go developer'), (2, 'python developer')")
+	if err != nil {
+		t.Fatalf("insert profiles: %v", err)
 	}
 	return db
 }

--- a/tests/query_select_test.go
+++ b/tests/query_select_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import "testing"
+
+func TestSelectColumns(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	var row map[string]any
+	if err := db.Table("users").Select("name").Where("id", 1).FirstMap(&row); err != nil {
+		t.Fatalf("select columns: %v", err)
+	}
+	if len(row) != 1 {
+		t.Errorf("expected 1 column, got %d", len(row))
+	}
+	if row["name"] != "alice" {
+		t.Errorf("expected alice, got %v", row["name"])
+	}
+}
+
+func TestDistinct(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	_, err := db.Table("users").Insert(map[string]any{"name": "carol", "age": 30})
+	if err != nil {
+		t.Fatalf("insert duplicate: %v", err)
+	}
+	var rows []map[string]any
+	if err := db.Table("users").Distinct("age").OrderBy("age", "asc").GetMaps(&rows); err != nil {
+		t.Fatalf("distinct: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0]["age"] != int64(25) || rows[1]["age"] != int64(30) {
+		t.Errorf("unexpected ages: %v", rows)
+	}
+}
+
+func TestLimitOffset(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	var rows []map[string]any
+	if err := db.Table("users").OrderBy("id", "asc").Offset(1).Limit(1).GetMaps(&rows); err != nil {
+		t.Fatalf("limit offset: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0]["name"] != "bob" {
+		t.Errorf("expected bob, got %v", rows[0]["name"])
+	}
+}
+
+func TestJoinSelect(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	var row map[string]any
+	err := db.Table("users").Join("profiles", "users.id", "=", "profiles.user_id").Select("users.name", "profiles.bio").Where("profiles.bio", "like", "%go%").FirstMap(&row)
+	if err != nil {
+		t.Fatalf("join select: %v", err)
+	}
+	if row["name"] != "alice" || row["bio"] != "go developer" {
+		t.Errorf("unexpected row: %v", row)
+	}
+}


### PR DESCRIPTION
## Summary
- extend test setup with profiles table for join queries
- add test coverage for select-related features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852f3d16b2c8328a1cfc61a8c56a2ca