### PR TITLE
Implement InsertGetId method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ if err != nil {
 
 var rows []map[string]any
 err = orm.Table("users").Where("age", ">", 20).GetMaps(&rows)
+
+// insert a record and get its auto-increment id
+newID, err := orm.Table("users").InsertGetId(map[string]any{"name": "sam", "age": 18})
+if err != nil {
+    log.Fatal(err)
+}
 ```
 
 Transactions are handled via `Transaction`:

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -317,6 +317,19 @@ func (q *Query) Insert(data map[string]any) (sql.Result, error) {
 	return q.exec.Exec(sqlStr, args...)
 }
 
+// InsertGetId executes an INSERT and returns the auto-increment ID.
+func (q *Query) InsertGetId(data map[string]any) (int64, error) {
+	res, err := q.Insert(data)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
 // InsertBatch executes a bulk INSERT with the given slice of data maps.
 func (q *Query) InsertBatch(data []map[string]any) (sql.Result, error) {
 	ib := qbapi.NewInsertQueryBuilder(qbmysql.NewMySQLQueryBuilder())

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -101,6 +101,25 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestInsertGetId(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	id, err := db.Table("users").InsertGetId(map[string]any{"name": "frank", "age": 28})
+	if err != nil {
+		t.Fatalf("insert get id: %v", err)
+	}
+	if id != 3 {
+		t.Errorf("expected id 3, got %d", id)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("id", id).FirstMap(&row); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if row["name"] != "frank" {
+		t.Errorf("expected frank, got %v", row["name"])
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- add `InsertGetId` for inserting a row and returning its ID
- document usage in README
- test `InsertGetId` behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853704b66448328917a9bafea8a8ff3