### PR TITLE
Add query locking

### DIFF
--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -297,6 +297,18 @@ func (q *Query) Take(n int) *Query { return q.Limit(n) }
 // Skip is an alias of Offset.
 func (q *Query) Skip(n int) *Query { return q.Offset(n) }
 
+// SharedLock adds LOCK IN SHARE MODE clause.
+func (q *Query) SharedLock() *Query {
+	q.builder.SharedLock()
+	return q
+}
+
+// LockForUpdate adds FOR UPDATE clause.
+func (q *Query) LockForUpdate() *Query {
+	q.builder.LockForUpdate()
+	return q
+}
+
 // Build returns the SQL and args.
 func (q *Query) Build() (string, []any, error) { return q.builder.Build() }
 

--- a/tests/lock_test.go
+++ b/tests/lock_test.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSharedLockBuild(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	sqlStr, err := db.Table("users").Where("id", 1).SharedLock().RawSQL()
+	if err != nil {
+		t.Fatalf("raw sql: %v", err)
+	}
+	if !strings.Contains(sqlStr, "LOCK IN SHARE MODE") {
+		t.Errorf("expected LOCK IN SHARE MODE, got %s", sqlStr)
+	}
+}
+
+func TestLockForUpdateBuild(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	sqlStr, err := db.Table("users").Where("id", 1).LockForUpdate().RawSQL()
+	if err != nil {
+		t.Fatalf("raw sql: %v", err)
+	}
+	if !strings.Contains(sqlStr, "FOR UPDATE") {
+		t.Errorf("expected FOR UPDATE, got %s", sqlStr)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `SharedLock` and `LockForUpdate` in query wrapper
- test lock SQL generation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853a5deea1883289e9ee8af69b73af5