### PR TITLE
Add raw SQL execution helpers

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -1,6 +1,7 @@
 package orm
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -12,7 +13,11 @@ import (
 // executor abstracts sql.DB and sql.Tx.
 type executor interface {
 	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	Exec(query string, args ...any) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 // DB provides main ORM interface.
@@ -52,4 +57,24 @@ func (db *DB) Model(v any) *query.Query {
 // Table creates a query for table name.
 func (db *DB) Table(name string) *query.Query {
 	return query.New(db.exec, name)
+}
+
+// Exec executes a raw SQL statement.
+func (db *DB) Exec(query string, args ...any) (sql.Result, error) {
+	return db.exec.Exec(query, args...)
+}
+
+// ExecContext executes a raw SQL statement with a context.
+func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return db.exec.ExecContext(ctx, query, args...)
+}
+
+// QueryRow executes a query that is expected to return at most one row.
+func (db *DB) QueryRow(query string, args ...any) *sql.Row {
+	return db.exec.QueryRow(query, args...)
+}
+
+// QueryRowContext executes a query with context returning at most one row.
+func (db *DB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return db.exec.QueryRowContext(ctx, query, args...)
 }

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -12,11 +12,17 @@ import (
 
 // executor abstracts sql.DB and sql.Tx.
 type executor interface {
+	// Query runs a SQL statement returning multiple rows.
 	Query(query string, args ...any) (*sql.Rows, error)
+	// QueryContext is the context-aware version of Query.
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	// QueryRow executes a query expected to return at most one row.
 	QueryRow(query string, args ...any) *sql.Row
+	// QueryRowContext executes a single-row query with context.
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	// Exec runs a SQL statement that doesn't return rows.
 	Exec(query string, args ...any) (sql.Result, error)
+	// ExecContext runs Exec with a context.
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
@@ -57,6 +63,16 @@ func (db *DB) Model(v any) *query.Query {
 // Table creates a query for table name.
 func (db *DB) Table(name string) *query.Query {
 	return query.New(db.exec, name)
+}
+
+// Query runs a raw SQL query returning multiple rows.
+func (db *DB) Query(q string, args ...any) (*sql.Rows, error) {
+	return db.exec.Query(q, args...)
+}
+
+// QueryContext runs Query with a context.
+func (db *DB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
+	return db.exec.QueryContext(ctx, q, args...)
 }
 
 // Exec executes a raw SQL statement.

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -14,7 +15,11 @@ import (
 // executor abstracts sql.DB and sql.Tx.
 type executor interface {
 	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	Exec(query string, args ...any) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 // Query wraps goquent QueryBuilder and the executor.

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -14,11 +14,17 @@ import (
 // Query wraps goquent QueryBuilder and the Driver.
 // executor abstracts sql.DB and sql.Tx.
 type executor interface {
+	// Query executes a statement returning multiple rows.
 	Query(query string, args ...any) (*sql.Rows, error)
+	// QueryContext is the context-aware form of Query.
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	// QueryRow executes a single-row query.
 	QueryRow(query string, args ...any) *sql.Row
+	// QueryRowContext executes QueryRow with a context.
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	// Exec runs a statement that does not return rows.
 	Exec(query string, args ...any) (sql.Result, error)
+	// ExecContext runs Exec with a context.
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 

--- a/tests/raw_sql_test.go
+++ b/tests/raw_sql_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -21,6 +22,19 @@ func TestExecAndQueryRow(t *testing.T) {
 	if name != "greg" {
 		t.Errorf("expected greg, got %s", name)
 	}
+
+	rows, err := db.Query("SELECT name FROM users ORDER BY id ASC")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var count int
+	for rows.Next() {
+		count++
+	}
+	if count == 0 {
+		t.Error("expected rows from Query")
+	}
 }
 
 func TestExecAndQueryRowContext(t *testing.T) {
@@ -39,5 +53,31 @@ func TestExecAndQueryRowContext(t *testing.T) {
 	}
 	if age != 31 {
 		t.Errorf("expected 31, got %d", age)
+	}
+
+	rows, err := db.QueryContext(ctx, "SELECT id FROM users")
+	if err != nil {
+		t.Fatalf("query context: %v", err)
+	}
+	rows.Close()
+}
+
+func TestCanceledContextErrors(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := db.ExecContext(ctx, "INSERT INTO users(name, age) VALUES('x',1)"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled exec, got %v", err)
+	}
+
+	if _, err := db.QueryContext(ctx, "SELECT 1"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled query, got %v", err)
+	}
+
+	if err := db.QueryRowContext(ctx, "SELECT 1").Scan(new(int)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled queryrow, got %v", err)
 	}
 }

--- a/tests/raw_sql_test.go
+++ b/tests/raw_sql_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"context"
+	"testing"
+)
+
+func TestExecAndQueryRow(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	_, err := db.Exec("INSERT INTO users(name, age) VALUES(?, ?)", "greg", 55)
+	if err != nil {
+		t.Fatalf("exec raw: %v", err)
+	}
+
+	var name string
+	if err := db.QueryRow("SELECT name FROM users WHERE name=?", "greg").Scan(&name); err != nil {
+		t.Fatalf("queryrow: %v", err)
+	}
+	if name != "greg" {
+		t.Errorf("expected greg, got %s", name)
+	}
+}
+
+func TestExecAndQueryRowContext(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, "UPDATE users SET age=? WHERE name=?", 31, "alice")
+	if err != nil {
+		t.Fatalf("exec context: %v", err)
+	}
+
+	var age int
+	if err := db.QueryRowContext(ctx, "SELECT age FROM users WHERE name=?", "alice").Scan(&age); err != nil {
+		t.Fatalf("queryrow context: %v", err)
+	}
+	if age != 31 {
+		t.Errorf("expected 31, got %d", age)
+	}
+}


### PR DESCRIPTION
## Summary
- expose exec/query interfaces to run raw SQL
- provide DB.Exec, DB.ExecContext, DB.QueryRow, DB.QueryRowContext
- test executing raw SQL and using context

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854f4d58b888328832fb390ae8b6188