### PR TITLE
Add manual transaction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ err := orm.Transaction(func(tx orm.Tx) error {
 })
 ```
 
+Manual transaction control is also available:
+```go
+tx, err := orm.Begin()
+if err != nil {
+    log.Fatal(err)
+}
+if _, err = tx.Table("users").Insert(map[string]any{"name": "sam"}); err != nil {
+    tx.Rollback()
+    log.Fatal(err)
+}
+if err = tx.Commit(); err != nil {
+    log.Fatal(err)
+}
+```
+
 ## Project Structure
 The repository follows the Onion Architecture:
 

--- a/orm/driver/driver.go
+++ b/orm/driver/driver.go
@@ -65,3 +65,12 @@ func (d *Driver) Transaction(fn func(Tx) error) error {
 	}
 	return tx.Commit()
 }
+
+// Begin starts a transaction and returns the Tx.
+func (d *Driver) Begin() (Tx, error) {
+	tx, err := d.DB.Begin()
+	if err != nil {
+		return Tx{}, err
+	}
+	return Tx{tx}, nil
+}

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -45,14 +45,27 @@ func Open(dsn string) (*DB, error) {
 func (db *DB) Close() error { return db.drv.Close() }
 
 // Tx represents a transaction-scoped DB wrapper.
-type Tx struct{ *DB }
+type Tx struct {
+	*DB
+	driver.Tx
+}
 
 // Transaction executes fn in a transaction.
 func (db *DB) Transaction(fn func(tx Tx) error) error {
 	return db.drv.Transaction(func(t driver.Tx) error {
 		txDB := &DB{drv: db.drv, exec: t.Tx}
-		return fn(Tx{txDB})
+		return fn(Tx{DB: txDB, Tx: t})
 	})
+}
+
+// Begin starts a transaction for manual control.
+func (db *DB) Begin() (Tx, error) {
+	t, err := db.drv.Begin()
+	if err != nil {
+		return Tx{}, err
+	}
+	txDB := &DB{drv: db.drv, exec: t.Tx}
+	return Tx{DB: txDB, Tx: t}, nil
 }
 
 // Model creates a query for the struct table.

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -44,6 +44,11 @@ func Open(dsn string) (*DB, error) {
 // Close closes underlying DB.
 func (db *DB) Close() error { return db.drv.Close() }
 
+// newTransactionDB wraps a sql.Tx in a DB instance bound to the same driver.
+func (db *DB) newTransactionDB(tx *sql.Tx) *DB {
+	return &DB{drv: db.drv, exec: tx}
+}
+
 // Tx represents a transaction-scoped DB wrapper.
 type Tx struct {
 	*DB
@@ -53,7 +58,7 @@ type Tx struct {
 // Transaction executes fn in a transaction.
 func (db *DB) Transaction(fn func(tx Tx) error) error {
 	return db.drv.Transaction(func(t driver.Tx) error {
-		txDB := &DB{drv: db.drv, exec: t.Tx}
+		txDB := db.newTransactionDB(t.Tx)
 		return fn(Tx{DB: txDB, Tx: t})
 	})
 }
@@ -64,7 +69,7 @@ func (db *DB) Begin() (Tx, error) {
 	if err != nil {
 		return Tx{}, err
 	}
-	txDB := &DB{drv: db.drv, exec: t.Tx}
+	txDB := db.newTransactionDB(t.Tx)
 	return Tx{DB: txDB, Tx: t}, nil
 }
 

--- a/tests/manual_transaction_test.go
+++ b/tests/manual_transaction_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestManualTxCommit(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Table("users").Insert(map[string]any{"name": "mallory", "age": 55}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("users").Where("name", "mallory").FirstMap(&row); err != nil {
+		t.Fatalf("select after commit: %v", err)
+	}
+	if row["age"] != int64(55) {
+		t.Errorf("expected age 55, got %v", row["age"])
+	}
+}
+
+func TestManualTxRollback(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Table("users").Insert(map[string]any{"name": "trent", "age": 44}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var row map[string]any
+	err = db.Table("users").Where("name", "trent").FirstMap(&row)
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected no rows after rollback, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow starting a transaction manually via `Begin`
- add `Begin` method in driver and orm layers
- embed underlying driver transaction in orm `Tx`
- test manual transaction commit and rollback
- document manual transaction usage in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854fcfc5f2083289114b06be52d52b7