### PR TITLE
Add Get method for struct slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ if err != nil {
 var rows []map[string]any
 err = orm.Table("users").Where("age", ">", 20).GetMaps(&rows)
 
+var users []User
+err = orm.Model(&User{}).Where("age", ">", 20).Get(&users)
+
 // insert a record and get its auto-increment id
 newID, err := orm.Table("users").InsertGetId(map[string]any{"name": "sam", "age": 18})
 if err != nil {

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -153,6 +153,23 @@ func (q *Query) GetMaps(dest *[]map[string]any) error {
 	return nil
 }
 
+// Get scans all rows into the slice pointed to by dest.
+func (q *Query) Get(dest any) error {
+	if q.err != nil {
+		return q.err
+	}
+	sqlStr, args, err := q.builder.Build()
+	if err != nil {
+		return err
+	}
+	rows, err := q.queryRows(sqlStr, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	return scanner.Structs(dest, rows)
+}
+
 // Limit sets a limit.
 func (q *Query) Limit(n int) *Query {
 	q.builder.Limit(int64(n))

--- a/orm/scanner/scanner.go
+++ b/orm/scanner/scanner.go
@@ -37,7 +37,7 @@ func Struct(dest any, rows *sql.Rows) error {
 				if fv.Type().ConvertibleTo(f.Type()) {
 					f.Set(fv.Convert(f.Type()))
 				} else {
-					return fmt.Errorf("type mismatch for %s", col)
+					return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
 				}
 			}
 		}
@@ -126,7 +126,7 @@ func Structs(dest any, rows *sql.Rows) error {
 					if fv.Type().ConvertibleTo(f.Type()) {
 						f.Set(fv.Convert(f.Type()))
 					} else {
-						return fmt.Errorf("type mismatch for %s", col)
+						return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
 					}
 				}
 			}

--- a/orm/scanner/scanner.go
+++ b/orm/scanner/scanner.go
@@ -92,6 +92,50 @@ func Maps(rows *sql.Rows) ([]map[string]any, error) {
 	return list, rows.Err()
 }
 
+// Structs scans all remaining rows into the slice pointed to by dest.
+// dest must be a pointer to a slice of structs.
+func Structs(dest any, rows *sql.Rows) error {
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("dest must be non-nil pointer to slice")
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Slice {
+		return fmt.Errorf("dest must point to slice")
+	}
+	elemType := v.Type().Elem()
+	for rows.Next() {
+		fields := make([]any, len(cols))
+		for i := range fields {
+			fields[i] = new(any)
+		}
+		if err := rows.Scan(fields...); err != nil {
+			return err
+		}
+		elem := reflect.New(elemType).Elem()
+		for i, col := range cols {
+			f := elem.FieldByNameFunc(func(name string) bool { return toSnake(name) == col })
+			if f.IsValid() && f.CanSet() {
+				val := reflect.ValueOf(fields[i]).Elem().Interface()
+				if val != nil {
+					fv := reflect.ValueOf(val)
+					if fv.Type().ConvertibleTo(f.Type()) {
+						f.Set(fv.Convert(f.Type()))
+					} else {
+						return fmt.Errorf("type mismatch for %s", col)
+					}
+				}
+			}
+		}
+		v.Set(reflect.Append(v, elem))
+	}
+	return rows.Err()
+}
+
 func toSnake(s string) string {
 	var out []rune
 	for i, r := range s {

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -71,6 +71,21 @@ func TestFirstMap(t *testing.T) {
 	}
 }
 
+func TestGetStructs(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	var users []User
+	if err := db.Model(&User{}).OrderBy("id", "asc").Get(&users); err != nil {
+		t.Fatalf("get structs: %v", err)
+	}
+	if len(users) != 2 {
+		t.Errorf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Name != "alice" || users[1].Name != "bob" {
+		t.Errorf("unexpected users: %+v", users)
+	}
+}
+
 func BenchmarkScannerMap(b *testing.B) {
 	db := setupDB(b)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- allow scanning all query results directly into a slice with `Query.Get`
- implement `scanner.Structs` for bulk struct conversion
- document `Get` usage in README
- test getting multiple structs from a query

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68550b499e448328b6b6fd91ff96667b