### PR TITLE
Expose underlying SQL DB

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -32,6 +32,14 @@ type DB struct {
 	exec executor
 }
 
+// SQLDB returns the underlying *sql.DB.
+func (db *DB) SQLDB() *sql.DB {
+	if db.drv == nil {
+		return nil
+	}
+	return db.drv.DB
+}
+
 // Open opens a MySQL database with default pooling.
 func Open(dsn string) (*DB, error) {
 	drv, err := driver.Open(dsn, 10, 10, time.Hour)


### PR DESCRIPTION
## Summary
- add `SQLDB` method to expose the raw `*sql.DB`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855204dc6908328a74e84dd022ed1b8