### PR TITLE
Fix panic when copying joins

### DIFF
--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -800,10 +800,10 @@ func deepCopyJoins(jb any) reflect.Value {
 	for _, name := range []string{"Joins", "JoinClauses", "LateralJoins"} {
 		slice := joinsVal.Elem().FieldByName(name)
 		if slice.IsValid() && !slice.IsNil() {
-			elemType := slice.Type().Elem()
-			newSlice := reflect.MakeSlice(elemType, slice.Elem().Len(), slice.Elem().Len())
+			sliceType := slice.Type()
+			newSlice := reflect.MakeSlice(sliceType, slice.Elem().Len(), slice.Elem().Len())
 			reflect.Copy(newSlice, slice.Elem())
-			newSlicePtr := reflect.New(elemType)
+			newSlicePtr := reflect.New(sliceType)
 			newSlicePtr.Elem().Set(newSlice)
 			newJoins.Elem().FieldByName(name).Set(newSlicePtr)
 		}

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -802,7 +802,9 @@ func deepCopyJoins(jb any) reflect.Value {
 		if slice.IsValid() && !slice.IsNil() {
 			cp := reflect.MakeSlice(slice.Type().Elem(), slice.Elem().Len(), slice.Elem().Len())
 			reflect.Copy(cp, slice.Elem())
-			newJoins.Elem().FieldByName(name).Set(cp.Addr())
+			cpPtr := reflect.New(slice.Type().Elem())
+			cpPtr.Elem().Set(cp)
+			newJoins.Elem().FieldByName(name).Set(cpPtr)
 		}
 	}
 	return newJoins

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -800,11 +800,12 @@ func deepCopyJoins(jb any) reflect.Value {
 	for _, name := range []string{"Joins", "JoinClauses", "LateralJoins"} {
 		slice := joinsVal.Elem().FieldByName(name)
 		if slice.IsValid() && !slice.IsNil() {
-			cp := reflect.MakeSlice(slice.Type().Elem(), slice.Elem().Len(), slice.Elem().Len())
-			reflect.Copy(cp, slice.Elem())
-			cpPtr := reflect.New(slice.Type().Elem())
-			cpPtr.Elem().Set(cp)
-			newJoins.Elem().FieldByName(name).Set(cpPtr)
+			elemType := slice.Type().Elem()
+			newSlice := reflect.MakeSlice(elemType, slice.Elem().Len(), slice.Elem().Len())
+			reflect.Copy(newSlice, slice.Elem())
+			newSlicePtr := reflect.New(elemType)
+			newSlicePtr.Elem().Set(newSlice)
+			newJoins.Elem().FieldByName(name).Set(newSlicePtr)
 		}
 	}
 	return newJoins

--- a/tests/deep_copy_joins_test.go
+++ b/tests/deep_copy_joins_test.go
@@ -1,0 +1,69 @@
+package tests
+
+import "testing"
+
+func TestUpdateWithJoinDeepCopy(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	_, err := db.Table("users").Join("profiles", "users.id", "=", "profiles.user_id").Where("profiles.bio", "=", "go developer").Update(map[string]any{"age": 55})
+	if err != nil {
+		t.Fatalf("update with join: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("id", 1).FirstMap(&row); err != nil {
+		t.Fatalf("select after update: %v", err)
+	}
+	if row["age"] != int64(55) {
+		t.Errorf("expected age 55, got %v", row["age"])
+	}
+}
+
+func TestUpdateWithLeftJoinDeepCopy(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	_, err := db.Table("users").LeftJoin("profiles", "users.id", "=", "profiles.user_id").Where("profiles.bio", "like", "%python%").Update(map[string]any{"age": 26})
+	if err != nil {
+		t.Fatalf("update with left join: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("id", 2).FirstMap(&row); err != nil {
+		t.Fatalf("select after update: %v", err)
+	}
+	if row["age"] != int64(26) {
+		t.Errorf("expected age 26, got %v", row["age"])
+	}
+}
+
+func TestUpdateWithCrossJoinDeepCopy(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	_, err := db.Table("users").CrossJoin("profiles").Where("profiles.user_id", "users.id").Where("profiles.bio", "=", "go developer").Update(map[string]any{"age": 60})
+	if err != nil {
+		t.Fatalf("update with cross join: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("id", 1).FirstMap(&row); err != nil {
+		t.Fatalf("select after cross join: %v", err)
+	}
+	if row["age"] != int64(60) {
+		t.Errorf("expected age 60, got %v", row["age"])
+	}
+}
+
+func TestDeleteWithJoinDeepCopy(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	_, err := db.Table("users").Join("profiles", "users.id", "=", "profiles.user_id").Where("profiles.bio", "=", "python developer").Delete()
+	if err != nil {
+		t.Fatalf("delete with join: %v", err)
+	}
+	var row map[string]any
+	err = db.Table("users").Where("id", 2).FirstMap(&row)
+	if err == nil {
+		t.Fatalf("expected no rows, got %+v", row)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid `cp.Addr()` on a non-addressable slice in `deepCopyJoins`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685532371be88328ad8b4e32d7c5f3af