### PR TITLE
Add missing builder wrappers

### DIFF
--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -230,6 +230,54 @@ func (q *Query) Join(table, localColumn, cond, target string) *Query {
 	return q
 }
 
+// JoinQuery adds a JOIN with additional ON/WHERE clauses defined in the callback.
+func (q *Query) JoinQuery(table string, fn func(b *qbapi.JoinClauseQueryBuilder)) *Query {
+	q.builder.JoinQuery(table, func(b *qbapi.JoinClauseQueryBuilder) { fn(b) })
+	return q
+}
+
+// LeftJoinQuery adds a LEFT JOIN with additional clauses defined in the callback.
+func (q *Query) LeftJoinQuery(table string, fn func(b *qbapi.JoinClauseQueryBuilder)) *Query {
+	q.builder.LeftJoinQuery(table, func(b *qbapi.JoinClauseQueryBuilder) { fn(b) })
+	return q
+}
+
+// RightJoinQuery adds a RIGHT JOIN with additional clauses defined in the callback.
+func (q *Query) RightJoinQuery(table string, fn func(b *qbapi.JoinClauseQueryBuilder)) *Query {
+	q.builder.RightJoinQuery(table, func(b *qbapi.JoinClauseQueryBuilder) { fn(b) })
+	return q
+}
+
+// JoinSubQuery joins a subquery with alias and join condition.
+func (q *Query) JoinSubQuery(sub *Query, alias, my, condition, target string) *Query {
+	q.builder.JoinSubQuery(sub.builder, alias, my, condition, target)
+	return q
+}
+
+// LeftJoinSubQuery performs a LEFT JOIN using a subquery.
+func (q *Query) LeftJoinSubQuery(sub *Query, alias, my, condition, target string) *Query {
+	q.builder.LeftJoinSubQuery(sub.builder, alias, my, condition, target)
+	return q
+}
+
+// RightJoinSubQuery performs a RIGHT JOIN using a subquery.
+func (q *Query) RightJoinSubQuery(sub *Query, alias, my, condition, target string) *Query {
+	q.builder.RightJoinSubQuery(sub.builder, alias, my, condition, target)
+	return q
+}
+
+// JoinLateral performs a LATERAL JOIN using a subquery.
+func (q *Query) JoinLateral(sub *Query, alias string) *Query {
+	q.builder.JoinLateral(sub.builder, alias)
+	return q
+}
+
+// LeftJoinLateral performs a LEFT LATERAL JOIN using a subquery.
+func (q *Query) LeftJoinLateral(sub *Query, alias string) *Query {
+	q.builder.LeftJoinLateral(sub.builder, alias)
+	return q
+}
+
 // LeftJoin adds LEFT JOIN clause.
 func (q *Query) LeftJoin(table, localColumn, cond, target string) *Query {
 	q.builder.LeftJoin(table, localColumn, cond, target)
@@ -326,6 +374,58 @@ func (q *Query) WhereRaw(raw string, vals map[string]any) *Query {
 // OrWhereRaw appends raw OR WHERE condition.
 func (q *Query) OrWhereRaw(raw string, vals map[string]any) *Query {
 	q.builder.OrWhereRaw(raw, vals)
+	return q
+}
+
+// SafeWhereRaw appends a raw WHERE condition ensuring a values map is always used.
+func (q *Query) SafeWhereRaw(raw string, vals map[string]any) *Query {
+	q.builder.SafeWhereRaw(raw, vals)
+	return q
+}
+
+// SafeOrWhereRaw appends a raw OR WHERE condition ensuring a values map is used.
+func (q *Query) SafeOrWhereRaw(raw string, vals map[string]any) *Query {
+	q.builder.SafeOrWhereRaw(raw, vals)
+	return q
+}
+
+// WhereGroup groups conditions with parentheses using AND logic.
+func (q *Query) WhereGroup(fn func(g *Query)) *Query {
+	q.builder.WhereGroup(func(b *qbapi.WhereSelectQueryBuilder) {
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		_ = setFieldValue(&grp.builder.WhereQueryBuilder, "builder", reflect.ValueOf(b.GetBuilder()))
+		fn(grp)
+	})
+	return q
+}
+
+// OrWhereGroup groups conditions with parentheses using OR logic.
+func (q *Query) OrWhereGroup(fn func(g *Query)) *Query {
+	q.builder.OrWhereGroup(func(b *qbapi.WhereSelectQueryBuilder) {
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		_ = setFieldValue(&grp.builder.WhereQueryBuilder, "builder", reflect.ValueOf(b.GetBuilder()))
+		fn(grp)
+	})
+	return q
+}
+
+// WhereNot groups conditions inside NOT (...).
+func (q *Query) WhereNot(fn func(g *Query)) *Query {
+	q.builder.WhereNot(func(b *qbapi.WhereSelectQueryBuilder) {
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		_ = setFieldValue(&grp.builder.WhereQueryBuilder, "builder", reflect.ValueOf(b.GetBuilder()))
+		fn(grp)
+	})
+	return q
+}
+
+// OrWhereNot groups conditions inside OR NOT (...).
+func (q *Query) OrWhereNot(fn func(g *Query)) *Query {
+	q.builder.OrWhereNot(func(b *qbapi.WhereSelectQueryBuilder) {
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		_ = setFieldValue(&grp.builder.WhereQueryBuilder, "builder", reflect.ValueOf(b.GetBuilder()))
+		fn(grp)
+	})
 	return q
 }
 

--- a/tests/query_wrapper_test.go
+++ b/tests/query_wrapper_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	qbapi "github.com/faciam-dev/goquent-query-builder/api"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm/query"
+)
+
+func TestJoinSubQueryWrapper(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	sub := db.Table("profiles").Select("user_id", "bio")
+
+	var row map[string]any
+	err := db.Table("users").
+		JoinSubQuery(sub, "p", "users.id", "=", "p.user_id").
+		Select("users.name", "p.bio").
+		Where("p.bio", "like", "%python%").
+		FirstMap(&row)
+	if err != nil {
+		t.Fatalf("join sub query: %v", err)
+	}
+	if row["name"] != "bob" {
+		t.Errorf("expected bob, got %v", row["name"])
+	}
+}
+
+func TestJoinQueryWrapper(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	var row map[string]any
+	err := db.Table("users").
+		JoinQuery("profiles", func(b *qbapi.JoinClauseQueryBuilder) {
+			b.On("users.id", "=", "profiles.user_id")
+		}).
+		Select("users.name", "profiles.bio").
+		Where("profiles.bio", "like", "%go%").
+		FirstMap(&row)
+	if err != nil {
+		t.Fatalf("join query: %v", err)
+	}
+	if row["name"] != "alice" {
+		t.Errorf("expected alice, got %v", row["name"])
+	}
+}
+
+func TestJoinLateralWrapper(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	sub := db.Table("profiles").
+		Select("bio", "user_id").
+		SafeWhereRaw("profiles.user_id = users.id", map[string]any{})
+
+	var row map[string]any
+	err := db.Table("users").
+		JoinLateral(sub, "p").
+		Select("users.name", "p.bio").
+		Where("p.bio", "like", "%go%").
+		FirstMap(&row)
+	if err != nil {
+		t.Fatalf("join lateral: %v", err)
+	}
+	if row["name"] != "alice" {
+		t.Errorf("expected alice, got %v", row["name"])
+	}
+}
+
+func TestSafeWhereRawAndGroups(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	var rows []map[string]any
+	err := db.Table("users").
+		WhereGroup(func(qb *query.Query) {
+			qb.SafeWhereRaw("name = :name", map[string]any{"name": "alice"})
+		}).
+		OrWhereGroup(func(qb *query.Query) {
+			qb.SafeWhereRaw("name = :name", map[string]any{"name": "bob"})
+		}).
+		OrderBy("id", "asc").
+		GetMaps(&rows)
+	if err != nil {
+		t.Fatalf("safe where raw group: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rows))
+	}
+}
+
+func TestWhereNotWrappers(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	var rows []map[string]any
+	err := db.Table("users").
+		WhereNot(func(qb *query.Query) {
+			qb.Where("name", "alice")
+		}).
+		OrderBy("id", "asc").
+		GetMaps(&rows)
+	if err != nil {
+		t.Fatalf("where not: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["name"] != "bob" {
+		t.Errorf("unexpected rows: %v", rows)
+	}
+}


### PR DESCRIPTION
## Summary
- wrap join subquery and lateral join operations
- expose safe raw where, grouped where, and NOT conditions
- add regression tests for join and where wrappers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855480543648328a277e0e6c1989f29