### PR TITLE
Fix scanner byte handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 )
 
-require filippo.io/edwards25519 v1.1.0 // indirect
+require (
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/faciam-dev/goquent-query-builder v0.0.0-20250619111145-259bb0c46fca h1:rwrVW/ZUfEk0vRBOFl30B3b4rgUGx9g+2StAiJb3XQg=
 github.com/faciam-dev/goquent-query-builder v0.0.0-20250619111145-259bb0c46fca/go.mod h1:4H0KSF3vKYF9ieLwrj5EOW1Q7c0ISSrq/cBLuJvOK7c=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=

--- a/orm/scanner/scanner.go
+++ b/orm/scanner/scanner.go
@@ -63,7 +63,12 @@ func Map(rows *sql.Rows) (map[string]any, error) {
 	}
 	m := make(map[string]any, len(cols))
 	for i, c := range cols {
-		m[c] = reflect.ValueOf(vals[i]).Elem().Interface()
+		v := reflect.ValueOf(vals[i]).Elem().Interface()
+		if b, ok := v.([]byte); ok {
+			m[c] = string(b)
+		} else {
+			m[c] = v
+		}
 	}
 	return m, nil
 }
@@ -85,7 +90,12 @@ func Maps(rows *sql.Rows) ([]map[string]any, error) {
 		}
 		m := make(map[string]any, len(cols))
 		for i, c := range cols {
-			m[c] = reflect.ValueOf(vals[i]).Elem().Interface()
+			v := reflect.ValueOf(vals[i]).Elem().Interface()
+			if b, ok := v.([]byte); ok {
+				m[c] = string(b)
+			} else {
+				m[c] = v
+			}
 		}
 		list = append(list, m)
 	}

--- a/tests/scanner_test.go
+++ b/tests/scanner_test.go
@@ -1,0 +1,72 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock" // TODO: consider removing external mock library
+
+	"github.com/faciam-dev/goquent/orm/scanner"
+)
+
+func TestMapConvertsBytes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "alice")
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	r, err := db.Query("SELECT id, name FROM users")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer r.Close()
+
+	m, err := scanner.Map(r)
+	if err != nil {
+		t.Fatalf("scan map: %v", err)
+	}
+	if m["name"] != "alice" {
+		t.Errorf("expected alice, got %v", m["name"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestMapsConvertsBytes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "alice").
+		AddRow(2, "bob")
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	r, err := db.Query("SELECT id, name FROM users")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer r.Close()
+
+	ms, err := scanner.Maps(r)
+	if err != nil {
+		t.Fatalf("scan maps: %v", err)
+	}
+	if len(ms) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(ms))
+	}
+	if ms[0]["name"] != "alice" || ms[1]["name"] != "bob" {
+		t.Errorf("unexpected rows: %v", ms)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- convert byte slices to strings in scanner
- add unit tests for map scanning using sqlmock

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855540ba55c8328a2ac406179dec40f