### PR TITLE
Add PostgreSQL driver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ It supports MySQL and PostgreSQL.
 
 ## Usage
 ```go
-import "github.com/faciam-dev/goquent/orm/conv"
-import "log"
+import (
+       "github.com/faciam-dev/goquent/orm"
+       "github.com/faciam-dev/goquent/orm/conv"
+       "log"
+)
 
-orm, _ := orm.Open(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
+orm, _ := orm.OpenWithDriver(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
 // PostgreSQL example
-// orm, _ := orm.Open(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
+// orm, _ := orm.OpenWithDriver(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
 user := new(User)
 err := orm.Model(user).Where("id", 1).First(user)
 
@@ -89,7 +92,7 @@ Run benchmarks with `go test -bench . ./tests`.
 Results on a GitHub Codespace (Go 1.23) show ~1.5x speedup over GORM for scanning operations.
 
 ## PostgreSQL Support
-The driver now includes a `PostgresDialect`. Use `orm.Open(orm.Postgres, dsn)` with a valid PostgreSQL DSN to connect.
+The driver now includes a `PostgresDialect`. Use `orm.OpenWithDriver(orm.Postgres, dsn)` with a valid PostgreSQL DSN to connect.
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # goquent ORM
 
 This package provides a minimal ORM built on top of [goquent-query-builder](https://github.com/faciam-dev/goquent-query-builder).
-It currently supports MySQL only.
+It supports MySQL and PostgreSQL.
 
 ## Usage
 ```go
 import "github.com/faciam-dev/goquent/orm/conv"
 import "log"
 
-orm, _ := orm.Open("root:password@tcp(localhost:3306)/testdb?parseTime=true")
+orm, _ := orm.Open(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
+// PostgreSQL example
+// orm, _ := orm.Open(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
 user := new(User)
 err := orm.Model(user).Where("id", 1).First(user)
 
@@ -86,8 +88,8 @@ The tests automatically create the required tables.
 Run benchmarks with `go test -bench . ./tests`.
 Results on a GitHub Codespace (Go 1.23) show ~1.5x speedup over GORM for scanning operations.
 
-## Extending to PostgreSQL
-The driver package is designed with dialect abstractions. Implementing a `postgresDialect` and adding support in `driver.Open` would enable PostgreSQL usage.
+## PostgreSQL Support
+The driver now includes a `PostgresDialect`. Use `orm.Open(orm.Postgres, dsn)` with a valid PostgreSQL DSN to connect.
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/faciam-dev/goquent
 go 1.23.8
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/faciam-dev/goquent-query-builder v0.0.0-20250619111145-259bb0c46fca
 	github.com/go-sql-driver/mysql v1.9.3
+	github.com/lib/pq v1.10.9
 )
 
-require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
-)
+require filippo.io/edwards25519 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/faciam-dev/goquent-query-builder v0.0.0-20250619111145-259bb0c46fca h
 github.com/faciam-dev/goquent-query-builder v0.0.0-20250619111145-259bb0c46fca/go.mod h1:4H0KSF3vKYF9ieLwrj5EOW1Q7c0ISSrq/cBLuJvOK7c=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -41,8 +41,14 @@ func (db *DB) SQLDB() *sql.DB {
 }
 
 // Open opens a MySQL database with default pooling.
-func Open(dsn string) (*DB, error) {
-	drv, err := driver.Open(dsn, 10, 10, time.Hour)
+const (
+	MySQL    = "mysql"
+	Postgres = "postgres"
+)
+
+// Open opens a database with default pooling for the given driver.
+func Open(driverName, dsn string) (*DB, error) {
+	drv, err := driver.Open(driverName, dsn, 10, 10, time.Hour)
 	if err != nil {
 		return nil, err
 	}
@@ -83,12 +89,12 @@ func (db *DB) Begin() (Tx, error) {
 
 // Model creates a query for the struct table.
 func (db *DB) Model(v any) *query.Query {
-	return query.New(db.exec, model.TableName(v))
+	return query.New(db.exec, model.TableName(v), db.drv.Dialect)
 }
 
 // Table creates a query for table name.
 func (db *DB) Table(name string) *query.Query {
-	return query.New(db.exec, name)
+	return query.New(db.exec, name, db.drv.Dialect)
 }
 
 // Query runs a raw SQL query returning multiple rows.

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -40,14 +40,20 @@ func (db *DB) SQLDB() *sql.DB {
 	return db.drv.DB
 }
 
-// Open opens a MySQL database with default pooling.
+// Database driver names.
 const (
 	MySQL    = "mysql"
 	Postgres = "postgres"
 )
 
-// Open opens a database with default pooling for the given driver.
-func Open(driverName, dsn string) (*DB, error) {
+// Open opens a MySQL database with default pooling. Deprecated: use
+// OpenWithDriver to specify a driver explicitly.
+func Open(dsn string) (*DB, error) {
+	return OpenWithDriver(MySQL, dsn)
+}
+
+// OpenWithDriver opens a database with default pooling for the given driver.
+func OpenWithDriver(driverName, dsn string) (*DB, error) {
 	drv, err := driver.Open(driverName, dsn, 10, 10, time.Hour)
 	if err != nil {
 		return nil, err

--- a/tests/orm_postgres_test.go
+++ b/tests/orm_postgres_test.go
@@ -1,0 +1,57 @@
+package tests
+
+import (
+	"database/sql"
+	"net"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm"
+	_ "github.com/lib/pq"
+)
+
+type PgUser struct {
+	ID   int    `orm:"column=id,primaryKey"`
+	Name string `orm:"column=name"`
+	Age  int    `orm:"column=age"`
+}
+
+func setupPgDB(t testing.TB) *orm.DB {
+	dsn := "postgres://postgres:password@localhost/testdb?sslmode=disable"
+	db, err := orm.OpenWithDriver(orm.Postgres, dsn)
+	if err != nil {
+		if _, ok := err.(*net.OpError); ok {
+			t.Skip("postgres not available")
+		}
+		t.Fatalf("open: %v", err)
+	}
+	stdDB, _ := sql.Open("postgres", dsn)
+	_, err = stdDB.Exec(`CREATE TABLE IF NOT EXISTS users (
+        id SERIAL PRIMARY KEY,
+        name TEXT,
+        age INT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = stdDB.Exec("TRUNCATE TABLE users")
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return db
+}
+
+func TestPostgresInsertSelect(t *testing.T) {
+	db := setupPgDB(t)
+	defer db.Close()
+	if _, err := db.Table("users").Insert(map[string]any{"name": "pg", "age": 10}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("name", "pg").FirstMap(&row); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if row["age"] != int64(10) {
+		t.Errorf("expected age 10, got %v", row["age"])
+	}
+}

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -17,7 +17,7 @@ type User struct {
 
 func setupDB(t testing.TB) *orm.DB {
 	dsn := "root:password@tcp(localhost:3306)/testdb?parseTime=true"
-	db, err := orm.Open(dsn)
+	db, err := orm.Open(orm.MySQL, dsn)
 	if err != nil {
 		if _, ok := err.(*net.OpError); ok {
 			t.Skip("mysql not available")

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -17,7 +17,7 @@ type User struct {
 
 func setupDB(t testing.TB) *orm.DB {
 	dsn := "root:password@tcp(localhost:3306)/testdb?parseTime=true"
-	db, err := orm.Open(orm.MySQL, dsn)
+	db, err := orm.OpenWithDriver(orm.MySQL, dsn)
 	if err != nil {
 		if _, ok := err.(*net.OpError); ok {
 			t.Skip("mysql not available")


### PR DESCRIPTION
## Summary
- implement `PostgresDialect` and driver selection
- allow orm.Open to choose between MySQL and PostgreSQL
- create helper builders in query package
- update README with Postgres instructions
- adapt tests and module dependencies

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855692d8af48328bbebb1d54aac9e25