### PR TITLE
Fix Where literal handling

### DIFF
--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
-	"strings"
 	"unsafe"
 
 	qbapi "github.com/faciam-dev/goquent-query-builder/api"
@@ -126,22 +125,14 @@ func (q *Query) Where(col string, args ...any) *Query {
 	}
 	switch len(args) {
 	case 1:
-		if s, ok := args[0].(string); ok && strings.Contains(s, ".") {
-			q.builder.WhereColumn([]string{col, s}, col, "=", s)
-		} else {
-			q.builder.Where(col, "=", args[0])
-		}
+		q.builder.Where(col, "=", args[0])
 	case 2:
 		op, ok := args[0].(string)
 		if !ok {
 			q.err = fmt.Errorf("invalid operator type")
 			return q
 		}
-		if s, ok := args[1].(string); ok && strings.Contains(s, ".") {
-			q.builder.WhereColumn([]string{col, s}, col, op, s)
-		} else {
-			q.builder.Where(col, op, args[1])
-		}
+		q.builder.Where(col, op, args[1])
 	default:
 		q.err = fmt.Errorf("invalid Where usage")
 	}

--- a/tests/deep_copy_joins_test.go
+++ b/tests/deep_copy_joins_test.go
@@ -40,7 +40,7 @@ func TestUpdateWithCrossJoinDeepCopy(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()
 
-	_, err := db.Table("users").CrossJoin("profiles").Where("profiles.user_id", "users.id").Where("profiles.bio", "=", "go developer").Update(map[string]any{"age": 60})
+	_, err := db.Table("users").CrossJoin("profiles").WhereColumn("profiles.user_id", "users.id").Where("profiles.bio", "=", "go developer").Update(map[string]any{"age": 60})
 	if err != nil {
 		t.Fatalf("update with cross join: %v", err)
 	}

--- a/tests/query_extra_test.go
+++ b/tests/query_extra_test.go
@@ -226,3 +226,20 @@ func TestWhereAnyAllSQL(t *testing.T) {
 		t.Errorf("expected AND in sql, got %s", sqlStr)
 	}
 }
+
+func TestWhereValueWithDot(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	if _, err := db.Table("users").Insert(map[string]any{"name": "a1.b2", "age": 22}); err != nil {
+		t.Fatalf("insert dotted value: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("users").Where("name", "a1.b2").FirstMap(&row); err != nil {
+		t.Fatalf("select dotted value: %v", err)
+	}
+	if row["age"] != int64(22) {
+		t.Errorf("expected age 22, got %v", row["age"])
+	}
+}


### PR DESCRIPTION
## Summary
- drop heuristic that treats dotted values as columns
- update cross join test to use explicit `WhereColumn`
- ensure dotted strings like `a1.b2` are handled as literals

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68566c5ec3bc8328bd579bb99e0de0ce