### PR TITLE
Add context-aware transaction APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ import (
        "log"
 )
 
-orm, _ := orm.OpenWithDriver(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
+db, _ := orm.OpenWithDriver(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
 // PostgreSQL example
-// orm, _ := orm.OpenWithDriver(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
+// db, _ := orm.OpenWithDriver(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
 user := new(User)
-err := orm.Model(user).Where("id", 1).First(user)
+err := db.Model(user).Where("id", 1).First(user)
 
 var row map[string]any
-err = orm.Table("users").Where("id", 1).FirstMap(&row)
+err = db.Table("users").Where("id", 1).FirstMap(&row)
 
 // fetch a typed value from a map
 id, err := conv.Value[uint64](row, "id")
@@ -27,13 +27,13 @@ if err != nil {
 }
 
 var rows []map[string]any
-err = orm.Table("users").Where("age", ">", 20).GetMaps(&rows)
+err = db.Table("users").Where("age", ">", 20).GetMaps(&rows)
 
 var users []User
-err = orm.Model(&User{}).Where("age", ">", 20).Get(&users)
+err = db.Model(&User{}).Where("age", ">", 20).Get(&users)
 
 // insert a record and get its auto-increment id
-newID, err := orm.Table("users").InsertGetId(map[string]any{"name": "sam", "age": 18})
+newID, err := db.Table("users").InsertGetId(map[string]any{"name": "sam", "age": 18})
 if err != nil {
     log.Fatal(err)
 }
@@ -41,7 +41,7 @@ if err != nil {
 
 Transactions are handled via `Transaction`:
 ```go
-err := orm.Transaction(func(tx orm.Tx) error {
+err := db.Transaction(func(tx orm.Tx) error {
     return tx.Table("users").Where("id", 1).First(&user)
 })
 ```
@@ -49,7 +49,7 @@ err := orm.Transaction(func(tx orm.Tx) error {
 Context-aware transactions are also available:
 ```go
 ctx := context.Background()
-err := orm.TransactionContext(ctx, func(tx orm.Tx) error {
+err := db.TransactionContext(ctx, func(tx orm.Tx) error {
     return tx.Table("users").Where("id", 1).First(&user)
 })
 ```
@@ -57,7 +57,7 @@ err := orm.TransactionContext(ctx, func(tx orm.Tx) error {
 Manual transaction control is also available:
 ```go
 ctx := context.Background()
-tx, err := orm.BeginTx(ctx, nil)
+tx, err := db.BeginTx(ctx, nil)
 if err != nil {
     log.Fatal(err)
 }
@@ -75,7 +75,7 @@ Values passed to `Where` are always treated as literals. To compare one column
 against another, use `WhereColumn`:
 
 ```go
-err := orm.Table("profiles").
+err := db.Table("profiles").
     WhereColumn("profiles.user_id", "users.id").
     Where("profiles.bio", "=", "go developer").
     FirstMap(&row)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,18 @@ err := orm.Transaction(func(tx orm.Tx) error {
 })
 ```
 
+Context-aware transactions are also available:
+```go
+ctx := context.Background()
+err := orm.TransactionContext(ctx, func(tx orm.Tx) error {
+    return tx.Table("users").Where("id", 1).First(&user)
+})
+```
+
 Manual transaction control is also available:
 ```go
-tx, err := orm.Begin()
+ctx := context.Background()
+tx, err := orm.BeginTx(ctx, nil)
 if err != nil {
     log.Fatal(err)
 }

--- a/orm/driver/driver.go
+++ b/orm/driver/driver.go
@@ -84,7 +84,7 @@ func (d *Driver) Transaction(fn func(Tx) error) error {
 	}
 	if err = fn(Tx{tx}); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
-			return rbErr
+			return fmt.Errorf("transaction error: %w, rollback error: %v", err, rbErr)
 		}
 		return err
 	}
@@ -108,7 +108,7 @@ func (d *Driver) TransactionContext(ctx context.Context, fn func(Tx) error) erro
 	}
 	if err = fn(Tx{tx}); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
-			return rbErr
+			return fmt.Errorf("transaction error: %w, rollback error: %v", err, rbErr)
 		}
 		return err
 	}

--- a/tests/transaction_context_test.go
+++ b/tests/transaction_context_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm"
+)
+
+func TestTransactionContextCommit(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	err := db.TransactionContext(ctx, func(tx orm.Tx) error {
+		_, err := tx.Table("users").Insert(map[string]any{"name": "ctx_dave", "age": 23})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("transaction context commit: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("users").Where("name", "ctx_dave").FirstMap(&row); err != nil {
+		t.Fatalf("select after commit: %v", err)
+	}
+	if row["age"] != int64(23) {
+		t.Errorf("expected age 23, got %v", row["age"])
+	}
+}
+
+func TestTransactionContextRollback(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	err := db.TransactionContext(ctx, func(tx orm.Tx) error {
+		if _, err := tx.Table("users").Insert(map[string]any{"name": "ctx_eve", "age": 51}); err != nil {
+			return err
+		}
+		return fmt.Errorf("rollback")
+	})
+	if err == nil || err.Error() != "rollback" {
+		t.Fatalf("expected rollback error, got %v", err)
+	}
+
+	var row map[string]any
+	err = db.Table("users").Where("name", "ctx_eve").FirstMap(&row)
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected no rows after rollback, got %v", err)
+	}
+}
+
+func TestBeginTxCommit(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if _, err := tx.Table("users").Insert(map[string]any{"name": "ctx_mallory", "age": 56}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("users").Where("name", "ctx_mallory").FirstMap(&row); err != nil {
+		t.Fatalf("select after commit: %v", err)
+	}
+	if row["age"] != int64(56) {
+		t.Errorf("expected age 56, got %v", row["age"])
+	}
+}
+
+func TestBeginTxRollback(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if _, err := tx.Table("users").Insert(map[string]any{"name": "ctx_trent", "age": 45}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var row map[string]any
+	err = db.Table("users").Where("name", "ctx_trent").FirstMap(&row)
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected no rows after rollback, got %v", err)
+	}
+}
+
+func TestBeginTxCanceled(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := db.BeginTx(ctx, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled begin tx, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `TransactionContext` and `BeginTx` with context support
- document usage of context-aware transactions
- test transaction functions with context

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856970dc5a48328b210d5308cc0d191