### PR TITLE
Fix count panic with multiple where clauses

### DIFF
--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -1023,7 +1023,9 @@ func setFieldValue(target any, field string, value reflect.Value) error {
 		return fmt.Errorf("type mismatch for field %q", field)
 	}
 	dest := reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem()
-	dest.Set(value)
+	src := reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem()
+	src.Set(value)
+	dest.Set(src)
 	return nil
 }
 

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -1022,10 +1022,15 @@ func setFieldValue(target any, field string, value reflect.Value) error {
 	if v.Type() != value.Type() {
 		return fmt.Errorf("type mismatch for field %q", field)
 	}
+	// Use unsafe to bypass Go's restrictions on setting unexported fields.
+	// v may reference a field from another package so we obtain a writable
+	// handle with reflect.NewAt and then assign through that handle.
 	dest := reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem()
-	src := reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem()
-	src.Set(value)
-	dest.Set(src)
+	// Create an addressable copy of the value instead of relying on
+	// value.UnsafeAddr which may panic if the value is not addressable.
+	copyVal := reflect.New(value.Type()).Elem()
+	copyVal.Set(value)
+	dest.Set(copyVal)
 	return nil
 }
 

--- a/tests/query_select_test.go
+++ b/tests/query_select_test.go
@@ -103,12 +103,25 @@ func TestCountWhere(t *testing.T) {
 func TestCountMultipleWhere(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()
-	c, err := db.Table("users").Where("age", ">", 20).Where("name", "=", "alice").Count("id")
-	if err != nil {
-		t.Fatalf("count multiple where: %v", err)
+	cases := []struct {
+		name string
+		user string
+		age  int
+		want int64
+	}{
+		{"match", "alice", 20, 1},
+		{"noMatch", "charlie", 20, 0},
 	}
-	if c != 1 {
-		t.Errorf("expected count 1, got %d", c)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := db.Table("users").Where("age", ">", tt.age).Where("name", "=", tt.user).Count("id")
+			if err != nil {
+				t.Fatalf("count multiple where: %v", err)
+			}
+			if c != tt.want {
+				t.Errorf("expected count %d, got %d", tt.want, c)
+			}
+		})
 	}
 }
 

--- a/tests/query_select_test.go
+++ b/tests/query_select_test.go
@@ -100,6 +100,18 @@ func TestCountWhere(t *testing.T) {
 	}
 }
 
+func TestCountMultipleWhere(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	c, err := db.Table("users").Where("age", ">", 20).Where("name", "=", "alice").Count("id")
+	if err != nil {
+		t.Fatalf("count multiple where: %v", err)
+	}
+	if c != 1 {
+		t.Errorf("expected count 1, got %d", c)
+	}
+}
+
 func TestCountJoin(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- fix reflection write for unexported fields in helper
- add regression test covering multiple Where with Count

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687684cf4b088328bf0352723829e0b1