### PR TITLE
Add custom driver registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ Results on a GitHub Codespace (Go 1.23) show ~1.5x speedup over GORM for scannin
 The driver now includes a `PostgresDialect`. Use `orm.OpenWithDriver(orm.Postgres, dsn)` with a valid PostgreSQL DSN to connect.
 
 ### Custom Drivers
-Additional `database/sql` drivers can be registered with `orm.RegisterDriver` and opened by name:
+Register a driver and optionally its SQL dialect so the ORM can infer quoting rules:
 
 ```go
-orm.RegisterDriver("mysql-custom", &mysql.MySQLDriver{})
+orm.RegisterDriverWithDialect("mysql-custom", &mysql.MySQLDriver{}, driver.MySQLDialect{})
 db, err := orm.OpenWithDriver("mysql-custom", dsn)
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,5 +115,13 @@ Results on a GitHub Codespace (Go 1.23) show ~1.5x speedup over GORM for scannin
 ## PostgreSQL Support
 The driver now includes a `PostgresDialect`. Use `orm.OpenWithDriver(orm.Postgres, dsn)` with a valid PostgreSQL DSN to connect.
 
+### Custom Drivers
+Additional `database/sql` drivers can be registered with `orm.RegisterDriver` and opened by name:
+
+```go
+orm.RegisterDriver("mysql-custom", &mysql.MySQLDriver{})
+db, err := orm.OpenWithDriver("mysql-custom", dsn)
+```
+
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/orm/driver_registry.go
+++ b/orm/driver_registry.go
@@ -1,0 +1,26 @@
+package orm
+
+import (
+	sqldriver "database/sql/driver"
+	"sync"
+)
+
+var (
+	driversMu sync.RWMutex
+	drivers   = make(map[string]sqldriver.Driver)
+)
+
+// RegisterDriver registers a database driver.
+func RegisterDriver(name string, d sqldriver.Driver) {
+	driversMu.Lock()
+	defer driversMu.Unlock()
+	drivers[name] = d
+}
+
+// GetDriver retrieves a registered driver.
+func GetDriver(name string) (sqldriver.Driver, bool) {
+	driversMu.RLock()
+	defer driversMu.RUnlock()
+	d, ok := drivers[name]
+	return d, ok
+}

--- a/orm/driver_registry.go
+++ b/orm/driver_registry.go
@@ -3,11 +3,15 @@ package orm
 import (
 	sqldriver "database/sql/driver"
 	"sync"
+
+	"github.com/faciam-dev/goquent/orm/driver"
 )
 
 var (
-	driversMu sync.RWMutex
-	drivers   = make(map[string]sqldriver.Driver)
+	driversMu  sync.RWMutex
+	drivers    = make(map[string]sqldriver.Driver)
+	dialectsMu sync.RWMutex
+	dialects   = make(map[string]driver.Dialect)
 )
 
 // RegisterDriver registers a database driver.
@@ -17,10 +21,30 @@ func RegisterDriver(name string, d sqldriver.Driver) {
 	drivers[name] = d
 }
 
+// RegisterDriverWithDialect registers a database driver along with its dialect.
+func RegisterDriverWithDialect(name string, d sqldriver.Driver, dialect driver.Dialect) {
+	RegisterDriver(name, d)
+	RegisterDialect(name, dialect)
+}
+
+// RegisterDialect registers a SQL dialect for a driver name.
+func RegisterDialect(name string, d driver.Dialect) {
+	dialectsMu.Lock()
+	defer dialectsMu.Unlock()
+	dialects[name] = d
+}
+
 // GetDriver retrieves a registered driver.
 func GetDriver(name string) (sqldriver.Driver, bool) {
 	driversMu.RLock()
 	defer driversMu.RUnlock()
 	d, ok := drivers[name]
+	return d, ok
+}
+
+func getDialect(name string) (driver.Dialect, bool) {
+	dialectsMu.RLock()
+	defer dialectsMu.RUnlock()
+	d, ok := dialects[name]
 	return d, ok
 }

--- a/tests/custom_driver_test.go
+++ b/tests/custom_driver_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"database/sql"
+	"net"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm"
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+func setupCustomDB(t testing.TB, drvName string) *orm.DB {
+	dsn := "root:password@tcp(localhost:3306)/testdb?parseTime=true"
+	db, err := orm.OpenWithDriver(drvName, dsn)
+	if err != nil {
+		if _, ok := err.(*net.OpError); ok {
+			t.Skip("mysql not available")
+		}
+		t.Fatalf("open: %v", err)
+	}
+	stdDB, _ := sql.Open("mysql", dsn)
+	_, err = stdDB.Exec(`CREATE TABLE IF NOT EXISTS users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(64),
+        age INT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = stdDB.Exec("TRUNCATE TABLE users")
+	if err != nil {
+		t.Fatalf("truncate table: %v", err)
+	}
+	_, err = stdDB.Exec("INSERT INTO users(name, age) VALUES ('cdrv', 1)")
+	if err != nil {
+		t.Fatalf("insert users: %v", err)
+	}
+	return db
+}
+
+func TestOpenWithRegisteredDriver(t *testing.T) {
+	orm.RegisterDriver("mysql-custom", &mysql.MySQLDriver{})
+	db := setupCustomDB(t, "mysql-custom")
+	defer db.Close()
+
+	var row map[string]any
+	if err := db.Table("users").Where("name", "cdrv").FirstMap(&row); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if row["age"] != int64(1) {
+		t.Errorf("expected age 1, got %v", row["age"])
+	}
+}

--- a/tests/custom_driver_test.go
+++ b/tests/custom_driver_test.go
@@ -3,14 +3,19 @@ package tests
 import (
 	"database/sql"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/faciam-dev/goquent/orm"
+	"github.com/faciam-dev/goquent/orm/driver"
 	mysql "github.com/go-sql-driver/mysql"
 )
 
 func setupCustomDB(t testing.TB, drvName string) *orm.DB {
-	dsn := "root:password@tcp(localhost:3306)/testdb?parseTime=true"
+	dsn := os.Getenv("TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("TEST_DB_DSN environment variable not set")
+	}
 	db, err := orm.OpenWithDriver(drvName, dsn)
 	if err != nil {
 		if _, ok := err.(*net.OpError); ok {
@@ -18,7 +23,10 @@ func setupCustomDB(t testing.TB, drvName string) *orm.DB {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	stdDB, _ := sql.Open("mysql", dsn)
+	stdDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
 	_, err = stdDB.Exec(`CREATE TABLE IF NOT EXISTS users (
         id INT AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(64),
@@ -40,7 +48,7 @@ func setupCustomDB(t testing.TB, drvName string) *orm.DB {
 }
 
 func TestOpenWithRegisteredDriver(t *testing.T) {
-	orm.RegisterDriver("mysql-custom", &mysql.MySQLDriver{})
+	orm.RegisterDriverWithDialect("mysql-custom", &mysql.MySQLDriver{}, driver.MySQLDialect{})
 	db := setupCustomDB(t, "mysql-custom")
 	defer db.Close()
 


### PR DESCRIPTION
## Summary
- support registering custom database drivers in `orm`
- open connections using registered drivers in `OpenWithDriver`
- document custom driver usage in README
- add regression test using a custom MySQL driver

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878ed2d14a083289b88dbde728008e0