### PR TITLE
Use RETURNING in PostgreSQL InsertGetId

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ newID, err := db.Table("users").InsertGetId(map[string]any{"name": "sam", "age":
 if err != nil {
     log.Fatal(err)
 }
+
+// specify a custom primary key column when needed
+altID, err := db.Table("accounts").PrimaryKey("account_id").InsertGetId(map[string]any{"name": "jane"})
+if err != nil {
+    log.Fatal(err)
+}
 ```
 
 Transactions are handled via `Transaction`:

--- a/docs/orm/README.md
+++ b/docs/orm/README.md
@@ -9,6 +9,10 @@ import "github.com/faciam-dev/goquent/orm"
 ## Index
 
 - [Constants](<#constants>)
+- [func GetDriver\(name string\) \(sqldriver.Driver, bool\)](<#GetDriver>)
+- [func RegisterDialect\(name string, d driver.Dialect\)](<#RegisterDialect>)
+- [func RegisterDriver\(name string, d sqldriver.Driver\)](<#RegisterDriver>)
+- [func RegisterDriverWithDialect\(name string, d sqldriver.Driver, dialect driver.Dialect\)](<#RegisterDriverWithDialect>)
 - [type DB](<#DB>)
   - [func Open\(dsn string\) \(\*DB, error\)](<#Open>)
   - [func OpenWithDriver\(driverName, dsn string\) \(\*DB, error\)](<#OpenWithDriver>)
@@ -39,6 +43,42 @@ const (
     Postgres = "postgres"
 )
 ```
+
+<a name="GetDriver"></a>
+## func GetDriver
+
+```go
+func GetDriver(name string) (sqldriver.Driver, bool)
+```
+
+GetDriver retrieves a registered driver.
+
+<a name="RegisterDialect"></a>
+## func RegisterDialect
+
+```go
+func RegisterDialect(name string, d driver.Dialect)
+```
+
+RegisterDialect registers a SQL dialect for a driver name.
+
+<a name="RegisterDriver"></a>
+## func RegisterDriver
+
+```go
+func RegisterDriver(name string, d sqldriver.Driver)
+```
+
+RegisterDriver registers a database driver.
+
+<a name="RegisterDriverWithDialect"></a>
+## func RegisterDriverWithDialect
+
+```go
+func RegisterDriverWithDialect(name string, d sqldriver.Driver, dialect driver.Dialect)
+```
+
+RegisterDriverWithDialect registers a database driver along with its dialect.
 
 <a name="DB"></a>
 ## type DB

--- a/docs/orm/query/README.md
+++ b/docs/orm/query/README.md
@@ -12,7 +12,7 @@ import "github.com/faciam-dev/goquent/orm/query"
   - [func New\(exec executor, table string, dialect driver.Dialect\) \*Query](<#New>)
   - [func \(q \*Query\) Avg\(col string\) \*Query](<#Query.Avg>)
   - [func \(q \*Query\) Build\(\) \(string, \[\]any, error\)](<#Query.Build>)
-  - [func \(q \*Query\) Count\(cols ...string\) (int64, error)](<#Query.Count>)
+  - [func \(q \*Query\) Count\(cols ...string\) \(int64, error\)](<#Query.Count>)
   - [func \(q \*Query\) CrossJoin\(table string\) \*Query](<#Query.CrossJoin>)
   - [func \(q \*Query\) Delete\(\) \(sql.Result, error\)](<#Query.Delete>)
   - [func \(q \*Query\) Distinct\(cols ...string\) \*Query](<#Query.Distinct>)
@@ -70,6 +70,7 @@ import "github.com/faciam-dev/goquent/orm/query"
   - [func \(q \*Query\) OrWhereYear\(col, cond, year string\) \*Query](<#Query.OrWhereYear>)
   - [func \(q \*Query\) OrderBy\(col, dir string\) \*Query](<#Query.OrderBy>)
   - [func \(q \*Query\) OrderByRaw\(raw string\) \*Query](<#Query.OrderByRaw>)
+  - [func \(q \*Query\) PrimaryKey\(col string\) \*Query](<#Query.PrimaryKey>)
   - [func \(q \*Query\) RawSQL\(\) \(string, error\)](<#Query.RawSQL>)
   - [func \(q \*Query\) ReOrder\(\) \*Query](<#Query.ReOrder>)
   - [func \(q \*Query\) RightJoin\(table, localColumn, cond, target string\) \*Query](<#Query.RightJoin>)
@@ -162,8 +163,7 @@ Build returns the SQL and args.
 func (q *Query) Count(cols ...string) (int64, error)
 ```
 
-Count executes a COUNT query and returns the row count. Pagination clauses such
-as `Limit` and `Offset` are ignored when generating the COUNT query.
+Count executes a COUNT query using the current conditions and returns the resulting row count.
 
 <a name="Query.CrossJoin"></a>
 ### func \(\*Query\) CrossJoin
@@ -289,7 +289,7 @@ InsertBatch executes a bulk INSERT with the given slice of data maps.
 func (q *Query) InsertGetId(data map[string]any) (int64, error)
 ```
 
-InsertGetId executes an INSERT and returns the auto\-increment ID. When using PostgreSQL, it appends a `RETURNING id` clause to retrieve the inserted identifier because the driver does not implement `LastInsertId`.
+InsertGetId executes an INSERT and returns the auto\-increment ID. For PostgreSQL, it appends a RETURNING clause for the configured primary key column because the driver does not support LastInsertId.
 
 <a name="Query.InsertOrIgnore"></a>
 ### func \(\*Query\) InsertOrIgnore
@@ -677,6 +677,15 @@ func (q *Query) OrderByRaw(raw string) *Query
 ```
 
 OrderByRaw adds raw ORDER BY clause.
+
+<a name="Query.PrimaryKey"></a>
+### func \(\*Query\) PrimaryKey
+
+```go
+func (q *Query) PrimaryKey(col string) *Query
+```
+
+PrimaryKey sets the primary key column for the table.
 
 <a name="Query.RawSQL"></a>
 ### func \(\*Query\) RawSQL

--- a/tests/orm_postgres_test.go
+++ b/tests/orm_postgres_test.go
@@ -55,3 +55,34 @@ func TestPostgresInsertSelect(t *testing.T) {
 		t.Errorf("expected age 10, got %v", row["age"])
 	}
 }
+
+func TestPostgresInsertGetId(t *testing.T) {
+	db := setupPgDB(t)
+	defer db.Close()
+	id, err := db.Table("users").InsertGetId(map[string]any{"name": "pg2", "age": 11})
+	if err != nil {
+		t.Fatalf("insert get id: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("expected id 1, got %d", id)
+	}
+}
+
+func TestPostgresInsertGetIdCustomPrimaryKey(t *testing.T) {
+	db := setupPgDB(t)
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS items (
+               item_id SERIAL PRIMARY KEY,
+               name TEXT
+       )`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	defer db.Exec("DROP TABLE items")
+	id, err := db.Table("items").PrimaryKey("item_id").InsertGetId(map[string]any{"name": "foo"})
+	if err != nil {
+		t.Fatalf("insert get id: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("expected id 1, got %d", id)
+	}
+}


### PR DESCRIPTION
## Summary
- add queryRow helper
- use RETURNING id for PostgreSQL InsertGetId
- document PostgreSQL InsertGetId behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a2e3a0867883289f5f6d53a2e939b8