### PR TITLE
feat: allow struct-based insert and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ newID, err := db.Table("users").InsertGetId(User{Name: "sam", Age: 18})
 if err != nil {
     log.Fatal(err)
 }
+// zero-value fields are inserted unless tagged with `omitempty`
 
 // specify a custom primary key column when needed
 altID, err := db.Table("accounts").PrimaryKey("account_id").InsertGetId(map[string]any{"name": "jane"})

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ err = db.Table("users").Where("age", ">", 20).GetMaps(&rows)
 var users []User
 err = db.Model(&User{}).Where("age", ">", 20).Get(&users)
 
-// insert a record and get its auto-increment id (uses RETURNING on PostgreSQL)
-newID, err := db.Table("users").InsertGetId(map[string]any{"name": "sam", "age": 18})
+// insert a record using a struct and get its auto-increment id
+newID, err := db.Table("users").InsertGetId(User{Name: "sam", Age: 18})
 if err != nil {
     log.Fatal(err)
 }
@@ -68,7 +68,7 @@ tx, err := db.BeginTx(ctx, nil)
 if err != nil {
     log.Fatal(err)
 }
-if _, err = tx.Table("users").Insert(map[string]any{"name": "sam"}); err != nil {
+if _, err = tx.Table("users").Insert(User{Name: "sam"}); err != nil {
     tx.Rollback()
     log.Fatal(err)
 }

--- a/docs/orm/query/README.md
+++ b/docs/orm/query/README.md
@@ -24,9 +24,9 @@ import "github.com/faciam-dev/goquent/orm/query"
   - [func \(q \*Query\) GroupBy\(cols ...string\) \*Query](<#Query.GroupBy>)
   - [func \(q \*Query\) Having\(col, cond string, val any\) \*Query](<#Query.Having>)
   - [func \(q \*Query\) HavingRaw\(raw string\) \*Query](<#Query.HavingRaw>)
-  - [func \(q \*Query\) Insert\(data map\[string\]any\) \(sql.Result, error\)](<#Query.Insert>)
+  - [func \(q \*Query\) Insert\(data any\) \(sql.Result, error\)](<#Query.Insert>)
   - [func \(q \*Query\) InsertBatch\(data \[\]map\[string\]any\) \(sql.Result, error\)](<#Query.InsertBatch>)
-  - [func \(q \*Query\) InsertGetId\(data map\[string\]any\) \(int64, error\)](<#Query.InsertGetId>)
+  - [func \(q \*Query\) InsertGetId\(data any\) \(int64, error\)](<#Query.InsertGetId>)
   - [func \(q \*Query\) InsertOrIgnore\(data \[\]map\[string\]any\) \(sql.Result, error\)](<#Query.InsertOrIgnore>)
   - [func \(q \*Query\) InsertUsing\(columns \[\]string, sub \*Query\) \(sql.Result, error\)](<#Query.InsertUsing>)
   - [func \(q \*Query\) Join\(table, localColumn, cond, target string\) \*Query](<#Query.Join>)
@@ -86,7 +86,7 @@ import "github.com/faciam-dev/goquent/orm/query"
   - [func \(q \*Query\) Take\(n int\) \*Query](<#Query.Take>)
   - [func \(q \*Query\) Union\(sub \*Query\) \*Query](<#Query.Union>)
   - [func \(q \*Query\) UnionAll\(sub \*Query\) \*Query](<#Query.UnionAll>)
-  - [func \(q \*Query\) Update\(data map\[string\]any\) \(sql.Result, error\)](<#Query.Update>)
+  - [func \(q \*Query\) Update\(data any\) \(sql.Result, error\)](<#Query.Update>)
   - [func \(q \*Query\) UpdateOrInsert\(cond map\[string\]any, values map\[string\]any\) \(sql.Result, error\)](<#Query.UpdateOrInsert>)
   - [func \(q \*Query\) Upsert\(data \[\]map\[string\]any, unique \[\]string, updateCols \[\]string\) \(sql.Result, error\)](<#Query.Upsert>)
   - [func \(q \*Query\) Where\(col string, args ...any\) \*Query](<#Query.Where>)
@@ -268,10 +268,10 @@ HavingRaw adds raw HAVING condition.
 ### func \(\*Query\) Insert
 
 ```go
-func (q *Query) Insert(data map[string]any) (sql.Result, error)
+func (q *Query) Insert(data any) (sql.Result, error)
 ```
 
-Insert executes an INSERT with the given data.
+Insert executes an INSERT with the given data. Maps or structs may be provided.
 
 <a name="Query.InsertBatch"></a>
 ### func \(\*Query\) InsertBatch
@@ -286,7 +286,7 @@ InsertBatch executes a bulk INSERT with the given slice of data maps.
 ### func \(\*Query\) InsertGetId
 
 ```go
-func (q *Query) InsertGetId(data map[string]any) (int64, error)
+func (q *Query) InsertGetId(data any) (int64, error)
 ```
 
 InsertGetId executes an INSERT and returns the auto\-increment ID. For PostgreSQL, it appends a RETURNING clause for the configured primary key column because the driver does not support LastInsertId.
@@ -826,10 +826,10 @@ UnionAll adds a UNION ALL with another query.
 ### func \(\*Query\) Update
 
 ```go
-func (q *Query) Update(data map[string]any) (sql.Result, error)
+func (q *Query) Update(data any) (sql.Result, error)
 ```
 
-Update executes an UPDATE with the given data.
+Update executes an UPDATE with the given data. Maps or structs may be provided.
 
 <a name="Query.UpdateOrInsert"></a>
 ### func \(\*Query\) UpdateOrInsert

--- a/tests/conv_test.go
+++ b/tests/conv_test.go
@@ -113,3 +113,24 @@ func TestMapToStructDBTag(t *testing.T) {
 		t.Errorf("unexpected user: %+v", u)
 	}
 }
+
+func TestStructToMapOmitempty(t *testing.T) {
+	type user struct {
+		Age   int  `db:"age"`
+		Flag  bool `db:"flag,omitempty"`
+		Score int
+	}
+	m, err := conv.StructToMap(user{})
+	if err != nil {
+		t.Fatalf("struct to map: %v", err)
+	}
+	if v, ok := m["age"]; !ok || v != 0 {
+		t.Errorf("expected age 0, got %v", v)
+	}
+	if _, ok := m["flag"]; ok {
+		t.Error("flag should be omitted")
+	}
+	if v, ok := m["score"]; !ok || v != 0 {
+		t.Errorf("expected score 0, got %v", v)
+	}
+}

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -167,6 +167,22 @@ func TestInsertGetId(t *testing.T) {
 	}
 }
 
+func TestInsertStructDBTag(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	u := UserSchema{Name: "greg", Age: 21, Schema: sql.NullString{String: "aux", Valid: true}}
+	if _, err := db.Model(&UserSchema{}).Insert(u); err != nil {
+		t.Fatalf("insert struct: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("name", "greg").FirstMap(&row); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if row["schema_name"] != "aux" {
+		t.Errorf("expected schema aux, got %v", row["schema_name"])
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()
@@ -185,6 +201,22 @@ func TestUpdate(t *testing.T) {
 	}
 	if row["age"] != int64(35) {
 		t.Errorf("expected age 35, got %v", row["age"])
+	}
+}
+
+func TestUpdateStruct(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	type upd struct{ Age int }
+	if _, err := db.Table("users").Where("name", "bob").Update(upd{Age: 36}); err != nil {
+		t.Fatalf("update struct: %v", err)
+	}
+	var row map[string]any
+	if err := db.Table("users").Where("name", "bob").FirstMap(&row); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if row["age"] != int64(36) {
+		t.Errorf("expected age 36, got %v", row["age"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- convert structs to maps respecting `db` tags
- support structs in `Insert`, `InsertGetId`, and `Update`
- document and test struct-based write operations

## Testing
- `go test ./...` *(fails: context deadline / no MySQL?)*

------
https://chatgpt.com/codex/tasks/task_e_68a41bc487d88328891c348c917989e9