### PR TITLE
feat: implement generic Select helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 - `Where` no longer attempts to automatically detect dotted values as column names.
   Use `WhereColumn` for column-to-column comparisons.
+- Added generic `SelectOne` and `SelectAll` APIs supporting struct and map destinations.
+- Added generic `Insert`, `Update`, and `Upsert` helpers with unified struct and map support.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It supports MySQL and PostgreSQL.
 ## Usage
 ```go
 import (
+       "context"
        "github.com/faciam-dev/goquent/orm"
        "github.com/faciam-dev/goquent/orm/conv"
        "log"
@@ -15,6 +16,12 @@ import (
 db, _ := orm.OpenWithDriver(orm.MySQL, "root:password@tcp(localhost:3306)/testdb?parseTime=true")
 // PostgreSQL example
 // db, _ := orm.OpenWithDriver(orm.Postgres, "postgres://user:pass@localhost/testdb?sslmode=disable")
+ctx := context.Background()
+u, _ := orm.SelectOne[User](ctx, db, "SELECT * FROM users WHERE id = ?", 1)
+rows, _ := orm.SelectAll[map[string]any](ctx, db, "SELECT * FROM users")
+
+_, _ = orm.Insert(ctx, db, User{Name: "sam", Age: 18})
+_, _ = orm.Update(ctx, db, User{ID: 1, Name: "Alice"}, orm.Columns("name"), orm.WherePK())
 user := new(User)
 err := db.Model(user).Where("id", 1).First(user)
 

--- a/orm/compat.go
+++ b/orm/compat.go
@@ -1,0 +1,23 @@
+package orm
+
+import "context"
+
+// Deprecated: Use SelectOne instead.
+func SelectStruct[T any](ctx context.Context, db *DB, q string, args ...any) (T, error) {
+	return SelectOne[T](ctx, db, q, args...)
+}
+
+// Deprecated: Use SelectAll instead.
+func SelectStructs[T any](ctx context.Context, db *DB, q string, args ...any) ([]T, error) {
+	return SelectAll[T](ctx, db, q, args...)
+}
+
+// Deprecated: Use SelectOne with map type instead.
+func (db *DB) SelectMap(ctx context.Context, q string, args ...any) (map[string]any, error) {
+	return SelectOne[map[string]any](ctx, db, q, args...)
+}
+
+// Deprecated: Use SelectAll with map type instead.
+func (db *DB) SelectMaps(ctx context.Context, q string, args ...any) ([]map[string]any, error) {
+	return SelectAll[map[string]any](ctx, db, q, args...)
+}

--- a/orm/meta.go
+++ b/orm/meta.go
@@ -1,0 +1,89 @@
+package orm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/faciam-dev/goquent/orm/internal/stringutil"
+)
+
+type fieldMeta struct {
+	Col       string
+	IndexPath []int
+	PK        bool
+	Readonly  bool
+	OmitEmpty bool
+}
+
+type typeMeta struct {
+	FieldsByName map[string]fieldMeta
+	FieldsByNorm map[string]fieldMeta
+	PKCols       []string
+}
+
+var metaCache sync.Map // map[reflect.Type]*typeMeta
+
+func normalize(name string) string {
+	return strings.ReplaceAll(strings.ToLower(name), "_", "")
+}
+
+func getTypeMeta(t reflect.Type) (*typeMeta, error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("type %s is not struct", t)
+	}
+	if m, ok := metaCache.Load(t); ok {
+		return m.(*typeMeta), nil
+	}
+	m := &typeMeta{
+		FieldsByName: make(map[string]fieldMeta),
+		FieldsByNorm: make(map[string]fieldMeta),
+	}
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if sf.PkgPath != "" { // unexported
+			continue
+		}
+		tag := sf.Tag.Get("db")
+		if tag == "-" {
+			continue
+		}
+		col := ""
+		var opts []string
+		if tag != "" {
+			parts := strings.Split(tag, ",")
+			col = parts[0]
+			if len(parts) > 1 {
+				opts = parts[1:]
+			}
+		}
+		if col == "" {
+			col = stringutil.ToSnake(sf.Name)
+		}
+		fm := fieldMeta{Col: col, IndexPath: sf.Index}
+		for _, o := range opts {
+			switch o {
+			case "pk":
+				fm.PK = true
+				m.PKCols = append(m.PKCols, col)
+			case "readonly":
+				fm.Readonly = true
+			case "omitempty":
+				fm.OmitEmpty = true
+			}
+		}
+		m.FieldsByName[col] = fm
+		m.FieldsByNorm[normalize(col)] = fm
+	}
+	metaCache.Store(t, m)
+	return m, nil
+}
+
+// ResetMetaCache clears cached reflection metadata. Intended for tests.
+func ResetMetaCache() {
+	metaCache = sync.Map{}
+}

--- a/orm/select.go
+++ b/orm/select.go
@@ -1,0 +1,221 @@
+package orm
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+)
+
+// SelectOne runs the query and scans the first row into T.
+func SelectOne[T any](ctx context.Context, db *DB, q string, args ...any) (T, error) {
+	var zero T
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return zero, err
+	}
+	defer rows.Close()
+
+	var t T
+	typ := reflect.TypeOf(t)
+	switch {
+	case isMapStringAny(typ):
+		cols, err := rows.Columns()
+		if err != nil {
+			return zero, err
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(any)
+		}
+		if !rows.Next() {
+			if err := rows.Err(); err != nil {
+				return zero, err
+			}
+			return zero, sql.ErrNoRows
+		}
+		if err := rows.Scan(vals...); err != nil {
+			return zero, err
+		}
+		m := make(map[string]any, len(cols))
+		for i, c := range cols {
+			v := reflect.ValueOf(vals[i]).Elem().Interface()
+			if b, ok := v.([]byte); ok {
+				m[c] = string(b)
+			} else {
+				m[c] = v
+			}
+		}
+		return any(m).(T), nil
+	case typ.Kind() == reflect.Struct:
+		meta, err := getTypeMeta(typ)
+		if err != nil {
+			return zero, err
+		}
+		cols, err := rows.Columns()
+		if err != nil {
+			return zero, err
+		}
+		fms := make([]fieldMeta, len(cols))
+		for i, c := range cols {
+			if fm, ok := meta.FieldsByName[c]; ok {
+				fms[i] = fm
+			} else if fm, ok := meta.FieldsByNorm[normalize(c)]; ok {
+				fms[i] = fm
+			}
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(any)
+		}
+		if !rows.Next() {
+			if err := rows.Err(); err != nil {
+				return zero, err
+			}
+			return zero, sql.ErrNoRows
+		}
+		if err := rows.Scan(vals...); err != nil {
+			return zero, err
+		}
+		v := reflect.New(typ).Elem()
+		scannerType := reflect.TypeOf((*sql.Scanner)(nil)).Elem()
+		for i, fm := range fms {
+			if fm.IndexPath == nil {
+				continue
+			}
+			val := reflect.ValueOf(vals[i]).Elem().Interface()
+			if val == nil {
+				continue
+			}
+			f := v.FieldByIndex(fm.IndexPath)
+			if !f.CanSet() {
+				continue
+			}
+			if reflect.PointerTo(f.Type()).Implements(scannerType) {
+				inst := reflect.New(f.Type())
+				if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
+					return zero, fmt.Errorf("scan %s: %w", fm.Col, err)
+				}
+				f.Set(inst.Elem())
+			} else {
+				fv := reflect.ValueOf(val)
+				if fv.Type().AssignableTo(f.Type()) {
+					f.Set(fv)
+				} else if fv.Type().ConvertibleTo(f.Type()) {
+					f.Set(fv.Convert(f.Type()))
+				} else {
+					return zero, fmt.Errorf("column %q type conversion failed: %s -> %s", fm.Col, fv.Type(), f.Type())
+				}
+			}
+		}
+		return v.Interface().(T), nil
+	default:
+		return zero, fmt.Errorf("unsupported type %s", typ)
+	}
+}
+
+// SelectAll runs the query and scans all rows into []T.
+func SelectAll[T any](ctx context.Context, db *DB, q string, args ...any) ([]T, error) {
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var t T
+	typ := reflect.TypeOf(t)
+	switch {
+	case isMapStringAny(typ):
+		cols, err := rows.Columns()
+		if err != nil {
+			return nil, err
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(any)
+		}
+		var res []T
+		for rows.Next() {
+			if err := rows.Scan(vals...); err != nil {
+				return nil, err
+			}
+			m := make(map[string]any, len(cols))
+			for i, c := range cols {
+				v := reflect.ValueOf(vals[i]).Elem().Interface()
+				if b, ok := v.([]byte); ok {
+					m[c] = string(b)
+				} else {
+					m[c] = v
+				}
+			}
+			res = append(res, any(m).(T))
+		}
+		return res, rows.Err()
+	case typ.Kind() == reflect.Struct:
+		meta, err := getTypeMeta(typ)
+		if err != nil {
+			return nil, err
+		}
+		cols, err := rows.Columns()
+		if err != nil {
+			return nil, err
+		}
+		fms := make([]fieldMeta, len(cols))
+		for i, c := range cols {
+			if fm, ok := meta.FieldsByName[c]; ok {
+				fms[i] = fm
+			} else if fm, ok := meta.FieldsByNorm[normalize(c)]; ok {
+				fms[i] = fm
+			}
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(any)
+		}
+		var res []T
+		scannerType := reflect.TypeOf((*sql.Scanner)(nil)).Elem()
+		for rows.Next() {
+			if err := rows.Scan(vals...); err != nil {
+				return nil, err
+			}
+			v := reflect.New(typ).Elem()
+			for i, fm := range fms {
+				if fm.IndexPath == nil {
+					continue
+				}
+				val := reflect.ValueOf(vals[i]).Elem().Interface()
+				if val == nil {
+					continue
+				}
+				f := v.FieldByIndex(fm.IndexPath)
+				if !f.CanSet() {
+					continue
+				}
+				if reflect.PointerTo(f.Type()).Implements(scannerType) {
+					inst := reflect.New(f.Type())
+					if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
+						return nil, fmt.Errorf("scan %s: %w", fm.Col, err)
+					}
+					f.Set(inst.Elem())
+				} else {
+					fv := reflect.ValueOf(val)
+					if fv.Type().AssignableTo(f.Type()) {
+						f.Set(fv)
+					} else if fv.Type().ConvertibleTo(f.Type()) {
+						f.Set(fv.Convert(f.Type()))
+					} else {
+						return nil, fmt.Errorf("column %q type conversion failed: %s -> %s", fm.Col, fv.Type(), f.Type())
+					}
+				}
+			}
+			res = append(res, v.Interface().(T))
+		}
+		return res, rows.Err()
+	default:
+		return nil, fmt.Errorf("unsupported type %s", typ)
+	}
+}
+
+func isMapStringAny(t reflect.Type) bool {
+	return t.Kind() == reflect.Map && t.Key().Kind() == reflect.String && t.Elem().Kind() == reflect.Interface && t.Elem().NumMethod() == 0
+}

--- a/orm/write.go
+++ b/orm/write.go
@@ -1,0 +1,384 @@
+package orm
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/faciam-dev/goquent/orm/driver"
+	"github.com/faciam-dev/goquent/orm/model"
+)
+
+// WriteOpt configures write behavior.
+type WriteOpt func(*writeOptions)
+
+type writeOptions struct {
+	cols      map[string]struct{}
+	omit      map[string]struct{}
+	wherePK   bool
+	returning []string
+	table     string
+}
+
+// Columns limits write to specified columns.
+func Columns(cols ...string) WriteOpt {
+	return func(o *writeOptions) {
+		if o.cols == nil {
+			o.cols = make(map[string]struct{}, len(cols))
+		}
+		for _, c := range cols {
+			o.cols[c] = struct{}{}
+		}
+	}
+}
+
+// Omit excludes specified columns.
+func Omit(cols ...string) WriteOpt {
+	return func(o *writeOptions) {
+		if o.omit == nil {
+			o.omit = make(map[string]struct{}, len(cols))
+		}
+		for _, c := range cols {
+			o.omit[c] = struct{}{}
+		}
+	}
+}
+
+// WherePK uses primary key columns in WHERE clause.
+func WherePK() WriteOpt { return func(o *writeOptions) { o.wherePK = true } }
+
+// Returning specifies columns to return (Postgres only).
+func Returning(cols ...string) WriteOpt { return func(o *writeOptions) { o.returning = cols } }
+
+// Table sets table name (required for map writes).
+func Table(name string) WriteOpt { return func(o *writeOptions) { o.table = name } }
+
+func applyWriteOpts(opts []WriteOpt) *writeOptions {
+	o := &writeOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func quote(d driver.Dialect, ident string) string { return d.QuoteIdent(ident) }
+
+func buildPlaceholders(d driver.Dialect, n int, start int) []string {
+	ph := make([]string, n)
+	for i := 0; i < n; i++ {
+		ph[i] = d.Placeholder(start + i)
+	}
+	return ph
+}
+
+// Insert inserts v into its table.
+func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
+	o := applyWriteOpts(opts)
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+	var table string
+	var cols []string
+	var args []any
+
+	if isMapStringAny(typ) {
+		if o.table == "" {
+			return nil, fmt.Errorf("Table option required for map writes")
+		}
+		table = o.table
+		iter := val.MapRange()
+		for iter.Next() {
+			col := iter.Key().String()
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[col]; ok {
+				continue
+			}
+			cols = append(cols, col)
+			args = append(args, iter.Value().Interface())
+		}
+	} else if typ.Kind() == reflect.Struct {
+		table = o.table
+		if table == "" {
+			table = model.TableName(v)
+		}
+		meta, err := getTypeMeta(typ)
+		if err != nil {
+			return nil, err
+		}
+		for _, fm := range meta.FieldsByName {
+			if fm.Readonly {
+				continue
+			}
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[fm.Col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[fm.Col]; ok {
+				continue
+			}
+			fv := val.FieldByIndex(fm.IndexPath)
+			if fm.OmitEmpty && fv.IsZero() {
+				continue
+			}
+			cols = append(cols, fm.Col)
+			args = append(args, fv.Interface())
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported type %s", typ)
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("no columns to insert")
+	}
+	ph := buildPlaceholders(db.drv.Dialect, len(cols), 1)
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = quote(db.drv.Dialect, c)
+	}
+	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	if len(o.returning) > 0 {
+		if _, ok := db.drv.Dialect.(driver.PostgresDialect); ok {
+			rc := make([]string, len(o.returning))
+			for i, c := range o.returning {
+				rc[i] = quote(db.drv.Dialect, c)
+			}
+			sqlStr += " RETURNING " + strings.Join(rc, ", ")
+		} else {
+			return nil, fmt.Errorf("Returning is not supported on dialect: %T", db.drv.Dialect)
+		}
+	}
+	return db.ExecContext(ctx, sqlStr, args...)
+}
+
+// Update updates record v.
+func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
+	o := applyWriteOpts(opts)
+	if !o.wherePK {
+		return nil, fmt.Errorf("Update[T] without WherePK is not allowed")
+	}
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+	var table string
+	var setParts []string
+	var whereParts []string
+	var args []any
+
+	if isMapStringAny(typ) {
+		if o.table == "" {
+			return nil, fmt.Errorf("Table option required for map writes")
+		}
+		table = o.table
+		iter := val.MapRange()
+		for iter.Next() {
+			col := iter.Key().String()
+			v := iter.Value()
+			if col == "id" { // treat id as PK
+				whereParts = append(whereParts, fmt.Sprintf("%s=%s", quote(db.drv.Dialect, col), db.drv.Dialect.Placeholder(len(args)+1)))
+				args = append(args, v.Interface())
+				continue
+			}
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[col]; ok {
+				continue
+			}
+			setParts = append(setParts, fmt.Sprintf("%s=%s", quote(db.drv.Dialect, col), db.drv.Dialect.Placeholder(len(args)+1)))
+			args = append(args, v.Interface())
+		}
+	} else if typ.Kind() == reflect.Struct {
+		table = o.table
+		if table == "" {
+			table = model.TableName(v)
+		}
+		meta, err := getTypeMeta(typ)
+		if err != nil {
+			return nil, err
+		}
+		for _, fm := range meta.FieldsByName {
+			fv := val.FieldByIndex(fm.IndexPath)
+			if fm.PK {
+				whereParts = append(whereParts, fmt.Sprintf("%s=%s", quote(db.drv.Dialect, fm.Col), db.drv.Dialect.Placeholder(len(args)+1)))
+				args = append(args, fv.Interface())
+				continue
+			}
+			if fm.Readonly {
+				continue
+			}
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[fm.Col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[fm.Col]; ok {
+				continue
+			}
+			if fm.OmitEmpty && fv.IsZero() {
+				continue
+			}
+			setParts = append(setParts, fmt.Sprintf("%s=%s", quote(db.drv.Dialect, fm.Col), db.drv.Dialect.Placeholder(len(args)+1)))
+			args = append(args, fv.Interface())
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported type %s", typ)
+	}
+	if len(whereParts) == 0 {
+		return nil, fmt.Errorf("WherePK requires pk values")
+	}
+	if len(setParts) == 0 {
+		return nil, fmt.Errorf("no columns to update")
+	}
+	sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE %s", quote(db.drv.Dialect, table), strings.Join(setParts, ", "), strings.Join(whereParts, " AND "))
+	if len(o.returning) > 0 {
+		if _, ok := db.drv.Dialect.(driver.PostgresDialect); ok {
+			rc := make([]string, len(o.returning))
+			for i, c := range o.returning {
+				rc[i] = quote(db.drv.Dialect, c)
+			}
+			sqlStr += " RETURNING " + strings.Join(rc, ", ")
+		} else {
+			return nil, fmt.Errorf("Returning is not supported on dialect: %T", db.drv.Dialect)
+		}
+	}
+	return db.ExecContext(ctx, sqlStr, args...)
+}
+
+// Upsert inserts or updates v using primary keys.
+func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
+	o := applyWriteOpts(opts)
+	if !o.wherePK {
+		return nil, fmt.Errorf("Upsert[T] without WherePK is not allowed")
+	}
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+	var table string
+	var cols []string
+	var args []any
+	var pkCols []string
+	var updateCols []string
+
+	if isMapStringAny(typ) {
+		if o.table == "" {
+			return nil, fmt.Errorf("Table option required for map writes")
+		}
+		table = o.table
+		iter := val.MapRange()
+		for iter.Next() {
+			col := iter.Key().String()
+			fv := iter.Value().Interface()
+			if col == "id" {
+				pkCols = append(pkCols, col)
+			}
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[col]; ok {
+				continue
+			}
+			cols = append(cols, col)
+			args = append(args, fv)
+		}
+		for _, c := range cols {
+			if c != "id" {
+				updateCols = append(updateCols, c)
+			}
+		}
+	} else if typ.Kind() == reflect.Struct {
+		table = o.table
+		if table == "" {
+			table = model.TableName(v)
+		}
+		meta, err := getTypeMeta(typ)
+		if err != nil {
+			return nil, err
+		}
+		for _, fm := range meta.FieldsByName {
+			fv := val.FieldByIndex(fm.IndexPath)
+			if fm.PK {
+				pkCols = append(pkCols, fm.Col)
+			}
+			if fm.Readonly {
+				continue
+			}
+			if len(o.cols) > 0 {
+				if _, ok := o.cols[fm.Col]; !ok {
+					continue
+				}
+			}
+			if _, ok := o.omit[fm.Col]; ok {
+				continue
+			}
+			if fm.OmitEmpty && fv.IsZero() {
+				continue
+			}
+			cols = append(cols, fm.Col)
+			args = append(args, fv.Interface())
+		}
+		for _, c := range cols {
+			foundPK := false
+			for _, pk := range pkCols {
+				if c == pk {
+					foundPK = true
+					break
+				}
+			}
+			if !foundPK {
+				updateCols = append(updateCols, c)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported type %s", typ)
+	}
+	if len(pkCols) == 0 {
+		return nil, fmt.Errorf("WherePK requires pk values")
+	}
+	ph := buildPlaceholders(db.drv.Dialect, len(cols), 1)
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = quote(db.drv.Dialect, c)
+	}
+	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	switch db.drv.Dialect.(type) {
+	case driver.MySQLDialect:
+		if len(updateCols) > 0 {
+			assigns := make([]string, len(updateCols))
+			for i, c := range updateCols {
+				assigns[i] = fmt.Sprintf("%s=VALUES(%s)", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c))
+			}
+			sqlStr += " ON DUPLICATE KEY UPDATE " + strings.Join(assigns, ", ")
+		}
+	case driver.PostgresDialect:
+		quotedPK := make([]string, len(pkCols))
+		for i, c := range pkCols {
+			quotedPK[i] = quote(db.drv.Dialect, c)
+		}
+		assigns := make([]string, len(updateCols))
+		for i, c := range updateCols {
+			assigns[i] = fmt.Sprintf("%s=EXCLUDED.%s", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c))
+		}
+		sqlStr += fmt.Sprintf(" ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(quotedPK, ", "), strings.Join(assigns, ", "))
+	default:
+		return nil, fmt.Errorf("upsert not supported on dialect: %T", db.drv.Dialect)
+	}
+	if len(o.returning) > 0 {
+		if _, ok := db.drv.Dialect.(driver.PostgresDialect); ok {
+			rc := make([]string, len(o.returning))
+			for i, c := range o.returning {
+				rc[i] = quote(db.drv.Dialect, c)
+			}
+			sqlStr += " RETURNING " + strings.Join(rc, ", ")
+		} else {
+			return nil, fmt.Errorf("Returning is not supported on dialect: %T", db.drv.Dialect)
+		}
+	}
+	return db.ExecContext(ctx, sqlStr, args...)
+}

--- a/tests/select_generic_test.go
+++ b/tests/select_generic_test.go
@@ -1,0 +1,104 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm"
+)
+
+func TestSelectOneMap(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	row, err := orm.SelectOne[map[string]any](ctx, db, "SELECT id, name FROM users WHERE id = ?", 1)
+	if err != nil {
+		t.Fatalf("select map: %v", err)
+	}
+	if row["name"] != "alice" {
+		t.Errorf("expected alice, got %v", row["name"])
+	}
+}
+
+func TestSelectAllStruct(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	users, err := orm.SelectAll[User](ctx, db, "SELECT id, name, age FROM users ORDER BY id")
+	if err != nil {
+		t.Fatalf("select structs: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Name != "alice" || users[1].Name != "bob" {
+		t.Errorf("unexpected users: %+v", users)
+	}
+}
+
+func TestSelectAllStructTag(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	users, err := orm.SelectAll[UserSchema](ctx, db, "SELECT id, name, age, schema_name FROM users ORDER BY id")
+	if err != nil {
+		t.Fatalf("select structs: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if !users[0].Schema.Valid || users[0].Schema.String != "main" {
+		t.Errorf("unexpected schema: %+v", users[0].Schema)
+	}
+}
+
+func TestSelectStructAlias(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	u, err := orm.SelectOne[User](ctx, db, "SELECT id AS ID, name AS Name, age FROM users WHERE id = ?", 1)
+	if err != nil {
+		t.Fatalf("select alias: %v", err)
+	}
+	if u.Name != "alice" {
+		t.Errorf("expected alice, got %v", u.Name)
+	}
+}
+
+func BenchmarkSelectStruct_Cold(b *testing.B) {
+	db := setupDB(b)
+	defer db.Close()
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		orm.ResetMetaCache()
+		if _, err := orm.SelectOne[User](ctx, db, "SELECT id, name, age FROM users WHERE id = 1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSelectStruct_Warm(b *testing.B) {
+	db := setupDB(b)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := orm.SelectOne[User](ctx, db, "SELECT id, name, age FROM users WHERE id = 1"); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := orm.SelectOne[User](ctx, db, "SELECT id, name, age FROM users WHERE id = 1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSelectMap(b *testing.B) {
+	db := setupDB(b)
+	defer db.Close()
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		if _, err := orm.SelectOne[map[string]any](ctx, db, "SELECT id, name, age FROM users WHERE id = 1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/tests/write_generic_test.go
+++ b/tests/write_generic_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/faciam-dev/goquent/orm"
+)
+
+func TestInsertStructGeneric(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	u := User{Name: "carol", Age: 33}
+	if _, err := orm.Insert(ctx, db, u); err != nil {
+		t.Fatalf("insert struct: %v", err)
+	}
+	var cnt int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users WHERE name = ?", u.Name).Scan(&cnt); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if cnt != 1 {
+		t.Errorf("expected 1, got %d", cnt)
+	}
+}
+
+func TestInsertMapGeneric(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	m := map[string]any{"name": "mapg", "age": 25}
+	if _, err := orm.Insert(ctx, db, m, orm.Table("users")); err != nil {
+		t.Fatalf("insert map: %v", err)
+	}
+	var cnt int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users WHERE name = ?", "mapg").Scan(&cnt); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if cnt != 1 {
+		t.Errorf("expected 1, got %d", cnt)
+	}
+}
+
+func TestUpdateStructWherePK(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	u := User{ID: 1, Name: "alice2"}
+	if _, err := orm.Update(ctx, db, u, orm.Columns("name"), orm.WherePK()); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	var name string
+	if err := db.QueryRowContext(ctx, "SELECT name FROM users WHERE id = 1").Scan(&name); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if name != "alice2" {
+		t.Errorf("expected alice2, got %s", name)
+	}
+}
+
+func TestUpdateStructNoWherePK(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	u := User{ID: 1, Name: "alice3"}
+	if _, err := orm.Update(ctx, db, u, orm.Columns("name")); err == nil {
+		t.Fatalf("expected error without WherePK")
+	}
+}
+
+func TestUpsertStruct(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+	ctx := context.Background()
+	// update existing
+	u := User{ID: 2, Name: "bob2"}
+	if _, err := orm.Upsert(ctx, db, u, orm.WherePK()); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	var name string
+	if err := db.QueryRowContext(ctx, "SELECT name FROM users WHERE id = 2").Scan(&name); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if name != "bob2" {
+		t.Errorf("expected bob2, got %s", name)
+	}
+	// insert new
+	u2 := User{ID: 10, Name: "newg"}
+	if _, err := orm.Upsert(ctx, db, u2, orm.WherePK()); err != nil {
+		t.Fatalf("upsert insert: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, "SELECT name FROM users WHERE id = 10").Scan(&name); err != nil {
+		t.Fatalf("select2: %v", err)
+	}
+	if name != "newg" {
+		t.Errorf("expected newg, got %s", name)
+	}
+}


### PR DESCRIPTION
## Summary
- add generic `Insert`, `Update`, and `Upsert` helpers with shared struct/map options
- document unified write API

## Testing
- `go test ./...`
- `go test -bench Select ./tests -run ^$`


------
https://chatgpt.com/codex/tasks/task_e_68a436a8b9bc8328a514f60d1e69856d