### PR TITLE
Fix scanner bool handling for MySQL tinyint columns

### DIFF
--- a/orm/scanner/scanner.go
+++ b/orm/scanner/scanner.go
@@ -33,23 +33,57 @@ func Struct(dest any, rows *sql.Rows) error {
 	scannerType := reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 	for i, col := range cols {
 		f := fieldByColumn(v, col)
-		if f.IsValid() && f.CanSet() {
-			val := reflect.ValueOf(fields[i]).Elem().Interface()
-			if val != nil {
-				if reflect.PointerTo(f.Type()).Implements(scannerType) {
-					inst := reflect.New(f.Type())
-					if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
-						return fmt.Errorf("scan %s: %w", col, err)
-					}
-					f.Set(inst.Elem())
-				} else {
-					fv := reflect.ValueOf(val)
-					if fv.Type().ConvertibleTo(f.Type()) {
-						f.Set(fv.Convert(f.Type()))
-					} else {
-						return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
-					}
-				}
+		if !f.IsValid() || !f.CanSet() {
+			continue
+		}
+		val := reflect.ValueOf(fields[i]).Elem().Interface()
+
+		// handle specialized bool types first
+		switch f.Type() {
+		case reflect.TypeOf(true):
+			b, err := parseBoolCompat(val)
+			if err != nil {
+				return fmt.Errorf("scan %s: %w", col, err)
+			}
+			f.SetBool(b)
+			continue
+		case reflect.TypeOf(sql.NullBool{}):
+			nb, err := parseNullBoolCompat(val)
+			if err != nil {
+				return fmt.Errorf("scan %s: %w", col, err)
+			}
+			f.Set(reflect.ValueOf(nb))
+			continue
+		}
+		if f.Kind() == reflect.Ptr && f.Type().Elem().Kind() == reflect.Bool {
+			pb, err := parsePtrBoolCompat(val)
+			if err != nil {
+				return fmt.Errorf("scan %s: %w", col, err)
+			}
+			if pb == nil {
+				f.Set(reflect.Zero(f.Type()))
+			} else {
+				f.Set(reflect.ValueOf(pb))
+			}
+			continue
+		}
+
+		if val == nil {
+			continue
+		}
+
+		if reflect.PointerTo(f.Type()).Implements(scannerType) {
+			inst := reflect.New(f.Type())
+			if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
+				return fmt.Errorf("scan %s: %w", col, err)
+			}
+			f.Set(inst.Elem())
+		} else {
+			fv := reflect.ValueOf(val)
+			if fv.Type().ConvertibleTo(f.Type()) {
+				f.Set(fv.Convert(f.Type()))
+			} else {
+				return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
 			}
 		}
 	}
@@ -141,23 +175,56 @@ func Structs(dest any, rows *sql.Rows) error {
 		elem := reflect.New(elemType).Elem()
 		for i, col := range cols {
 			f := fieldByColumn(elem, col)
-			if f.IsValid() && f.CanSet() {
-				val := reflect.ValueOf(fields[i]).Elem().Interface()
-				if val != nil {
-					if reflect.PointerTo(f.Type()).Implements(scannerType) {
-						inst := reflect.New(f.Type())
-						if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
-							return fmt.Errorf("scan %s: %w", col, err)
-						}
-						f.Set(inst.Elem())
-					} else {
-						fv := reflect.ValueOf(val)
-						if fv.Type().ConvertibleTo(f.Type()) {
-							f.Set(fv.Convert(f.Type()))
-						} else {
-							return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
-						}
-					}
+			if !f.IsValid() || !f.CanSet() {
+				continue
+			}
+			val := reflect.ValueOf(fields[i]).Elem().Interface()
+
+			switch f.Type() {
+			case reflect.TypeOf(true):
+				b, err := parseBoolCompat(val)
+				if err != nil {
+					return fmt.Errorf("scan %s: %w", col, err)
+				}
+				f.SetBool(b)
+				continue
+			case reflect.TypeOf(sql.NullBool{}):
+				nb, err := parseNullBoolCompat(val)
+				if err != nil {
+					return fmt.Errorf("scan %s: %w", col, err)
+				}
+				f.Set(reflect.ValueOf(nb))
+				continue
+			}
+			if f.Kind() == reflect.Ptr && f.Type().Elem().Kind() == reflect.Bool {
+				pb, err := parsePtrBoolCompat(val)
+				if err != nil {
+					return fmt.Errorf("scan %s: %w", col, err)
+				}
+				if pb == nil {
+					f.Set(reflect.Zero(f.Type()))
+				} else {
+					f.Set(reflect.ValueOf(pb))
+				}
+				continue
+			}
+
+			if val == nil {
+				continue
+			}
+
+			if reflect.PointerTo(f.Type()).Implements(scannerType) {
+				inst := reflect.New(f.Type())
+				if err := inst.Interface().(sql.Scanner).Scan(val); err != nil {
+					return fmt.Errorf("scan %s: %w", col, err)
+				}
+				f.Set(inst.Elem())
+			} else {
+				fv := reflect.ValueOf(val)
+				if fv.Type().ConvertibleTo(f.Type()) {
+					f.Set(fv.Convert(f.Type()))
+				} else {
+					return fmt.Errorf("type mismatch for column %s: expected %s, got %s", col, f.Type().String(), fv.Type().String())
 				}
 			}
 		}
@@ -197,4 +264,56 @@ func parseTag(tag string) string {
 		}
 	}
 	return ""
+}
+
+// bool parsing helpers with default compatibility policy
+
+func parseBoolCompat(src any) (bool, error) {
+	switch v := src.(type) {
+	case bool:
+		return v, nil
+	case int64:
+		if v == 0 {
+			return false, nil
+		}
+		if v == 1 {
+			return true, nil
+		}
+	case string:
+		x := strings.TrimSpace(strings.ToLower(v))
+		switch x {
+		case "true", "t", "1":
+			return true, nil
+		case "false", "f", "0":
+			return false, nil
+		}
+	case []byte:
+		return parseBoolCompat(string(v))
+	case nil:
+		// nil into bool is an error
+		return false, fmt.Errorf("cannot parse bool from <nil>")
+	}
+	return false, fmt.Errorf("cannot parse bool from %T(%v)", src, src)
+}
+
+func parseNullBoolCompat(src any) (sql.NullBool, error) {
+	if src == nil {
+		return sql.NullBool{Bool: false, Valid: false}, nil
+	}
+	b, err := parseBoolCompat(src)
+	if err != nil {
+		return sql.NullBool{}, err
+	}
+	return sql.NullBool{Bool: b, Valid: true}, nil
+}
+
+func parsePtrBoolCompat(src any) (*bool, error) {
+	if src == nil {
+		return nil, nil
+	}
+	b, err := parseBoolCompat(src)
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
 }

--- a/tests/scanner_test.go
+++ b/tests/scanner_test.go
@@ -183,3 +183,42 @@ func TestStructsDBRecord(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestStructBoolFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"nullable", "flag", "ptr"}).AddRow(int64(1), int64(0), int64(1))
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	r, err := db.Query("SELECT nullable, flag, ptr FROM t")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer r.Close()
+
+	var out struct {
+		Nullable bool
+		Flag     sql.NullBool
+		Ptr      *bool
+	}
+	if err := scanner.Struct(&out, r); err != nil {
+		t.Fatalf("scan struct: %v", err)
+	}
+	if !out.Nullable {
+		t.Errorf("nullable not true: %v", out.Nullable)
+	}
+	if !out.Flag.Valid || out.Flag.Bool {
+		t.Errorf("flag not false: %+v", out.Flag)
+	}
+	if out.Ptr == nil || !*out.Ptr {
+		t.Errorf("ptr not true: %v", out.Ptr)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- support bool, sql.NullBool, and *bool fields in scanner.Struct/Structs
- add compatibility bool parsing helpers and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4e6f7f48328ae350bfab362238e