### PR TITLE
Add typed returning writes and PG conflict target options

### DIFF
--- a/docs/orm/generic-crud.md
+++ b/docs/orm/generic-crud.md
@@ -7,6 +7,9 @@ The generic API is the small set of helpers around:
 - `Insert[T]`
 - `Update[T]`
 - `Upsert[T]`
+- `InsertReturning[T]`
+- `UpdateReturning[T]`
+- `UpsertReturning[T]`
 
 Use these helpers when you want a compact typed call and the operation is simple enough to fit their model. Use the query-builder API when you want to build SQL fluently with `db.Model(...).Where(...).Get(...)`, `db.Table(...).Where(...).FirstMap(...)`, joins, non-primary-key updates, or other builder features.
 
@@ -49,6 +52,7 @@ The write side of the generic API builds simple `INSERT`, `UPDATE`, and `UPSERT`
 _, err := orm.Insert(ctx, db, User{Name: "sam", Age: 18})
 _, err = orm.Update(ctx, db, User{ID: 1, Name: "sam"}, orm.Columns("name"), orm.WherePK())
 _, err = orm.Upsert(ctx, db, User{ID: 1, Name: "sam", Age: 18}, orm.WherePK())
+created, err := orm.InsertReturning[User](ctx, db, User{Name: "sam", Age: 18})
 ```
 
 For anything more complex than "write this row to this table", prefer
@@ -82,6 +86,7 @@ users, err := orm.SelectAllBy[User](
 )
 
 _, err = orm.UpdateBy(ctx, db.Table("users"), map[string]any{"age": 55}, WithProfile(), BioLike("%go%"))
+updated, err := orm.UpdateByReturning[User](ctx, db, db.Table("users"), map[string]any{"age": 55}, WithProfile(), BioLike("%go%"))
 _, err = orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"))
 ```
 
@@ -160,6 +165,23 @@ For map destinations:
 - keys are the column names returned by the database,
 - values are stored as `any`,
 - `[]byte` values are converted to `string`.
+
+### Numeric columns
+
+Drivers do not all return SQL `numeric`/`decimal` values as the same Go type when scanning through `any`. PostgreSQL drivers commonly expose exact numeric values as text-like data. For portable DTOs, prefer one of these shapes:
+
+- Use `string` or `sql.NullString` in persistence rows when you need exact decimal text, then parse or round in your domain layer.
+- Use a custom type that implements `sql.Scanner` when the column has business-specific decimal semantics.
+- Use `float64` only when precision loss is acceptable and your driver returns a value convertible to `float64`.
+
+Example:
+
+```go
+type ScoreRow struct {
+    ID         string `db:"id"`
+    Confidence string `db:"confidence"` // numeric(4,3)
+}
+```
 
 ## Write API
 
@@ -243,11 +265,12 @@ _, err := orm.Update(
 
 ### `Upsert[T]`
 
-`Upsert` also requires `WherePK()`.
+`Upsert` requires either `WherePK()` or an explicit conflict target.
 
 - On MySQL it builds `INSERT ... ON DUPLICATE KEY UPDATE ...`.
 - On PostgreSQL it builds `INSERT ... ON CONFLICT (...) DO UPDATE ...`.
 - Primary-key columns used by `WherePK()` are always kept in the `INSERT` side of the statement, even if `Columns(...)`, `Omit(...)`, or `omitempty` would otherwise exclude them.
+- Columns named by `ConflictColumns(...)` are also kept in the `INSERT` side of the statement.
 
 If there are no non-primary-key columns left to update after filtering, the helper falls back to a no-op conflict action:
 
@@ -262,6 +285,65 @@ _, err := orm.Upsert(
     orm.WherePK(),
 )
 ```
+
+For a PostgreSQL partial unique index, pass the indexed columns plus the index predicate:
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{
+        "tenant_id":       tenantID,
+        "idempotency_key": key,
+        "payload_json":    payload,
+    },
+    orm.Table("ai_audit_logs"),
+    orm.ConflictColumns("tenant_id", "idempotency_key"),
+    orm.ConflictWhere("idempotency_key <> ''"),
+)
+```
+
+For a PostgreSQL named unique constraint, use `ConflictConstraint(...)`:
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{"email": email, "name": name},
+    orm.Table("users"),
+    orm.ConflictConstraint("users_email_key"),
+)
+```
+
+### Typed returning helpers
+
+`InsertReturning[T]`, `UpdateReturning[T]`, and `UpsertReturning[T]` execute the same generated write statements as `Insert`, `Update`, and `Upsert`, but scan the PostgreSQL `RETURNING` row into `T`.
+
+If you do not pass `Returning(...)`, goquent infers the returning column list from the destination struct tags.
+
+```go
+created, err := orm.InsertReturning[User](
+    ctx,
+    db,
+    User{Name: "sam", Age: 18, Active: true},
+)
+```
+
+For scoped updates, use `UpdateByReturning[T]`:
+
+```go
+updated, err := orm.UpdateByReturning[User](
+    ctx,
+    db,
+    db.Table("users"),
+    map[string]any{"active": true},
+    func(q *query.Query) *query.Query {
+        return q.Where("tenant_id", tenantID).Where("id", id)
+    },
+)
+```
+
+Map return values cannot infer a column list. For `InsertReturning`, `UpdateReturning`, and `UpsertReturning`, pass `Returning(...)` when the destination is `map[string]any`. `UpdateByReturning` currently infers columns from a struct destination.
 
 ## Write options
 
@@ -296,7 +378,7 @@ If you use both `Columns(...)` and `Omit(...)`, `Omit(...)` still removes the om
 
 ### `WherePK()`
 
-`WherePK()` is required for `Update` and `Upsert`.
+`WherePK()` is required for `Update`. `Upsert` can use `WherePK()` or an explicit conflict target.
 
 - Struct writes: use fields tagged with `db:"...,pk"`.
 - Map writes: use `PK(...)`.
@@ -321,7 +403,39 @@ _, err := orm.Update(
 )
 ```
 
-These helpers still return `sql.Result`. They do not expose returned row values directly.
+`Insert`, `Update`, and `Upsert` still return `sql.Result` when you use `Returning(...)`; they consume the returned rows to count affected rows. Use the typed returning helpers when you need row values.
+
+### `ConflictColumns(...)`
+
+`ConflictColumns` sets the `ON CONFLICT (...)` target for `Upsert`. It is useful for natural unique keys and PostgreSQL partial unique indexes.
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{"tenant_id": tenantID, "external_key": key, "payload_json": payload},
+    orm.Table("events"),
+    orm.ConflictColumns("tenant_id", "external_key"),
+)
+```
+
+### `ConflictWhere(...)`
+
+`ConflictWhere` appends a PostgreSQL partial-index predicate to the conflict target. The predicate is a raw SQL fragment and is validated to reject statement separators, comments, and write/DDL keywords.
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    event,
+    orm.ConflictColumns("tenant_id", "idempotency_key"),
+    orm.ConflictWhere("idempotency_key <> ''"),
+)
+```
+
+### `ConflictConstraint(...)`
+
+`ConflictConstraint` builds `ON CONFLICT ON CONSTRAINT ...` for PostgreSQL named unique constraints. It cannot be combined with `ConflictColumns(...)` or `ConflictWhere(...)`.
 
 ### `Table(...)`
 
@@ -485,14 +599,15 @@ _, err := orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"
 
 - Reads only support struct destinations and `map[string]any`. Pointer destinations are not supported.
 - Writes only support non-pointer struct values and `map[string]any`.
-- Generic writes only support primary-key-based `Update` and `Upsert` through `WherePK()`. For arbitrary predicates, use the query-builder API.
+- Generic `Update` only supports primary-key-based updates through `WherePK()`. For arbitrary predicates, use `UpdateBy` or `UpdateByReturning`.
+- Generic `Upsert` can use `WherePK()`, `ConflictColumns(...)`, or `ConflictConstraint(...)`.
 - Scoped helpers are the recommended bridge when you want arbitrary predicates, joins, or `DELETE` while still keeping generic read/write helpers as the main public API.
 - Struct `Update` and `Upsert` depend on `db:"...,pk"` tags. Without them, `WherePK()` has no primary-key columns to use.
 - Since generic writes take struct values, a `TableName() string` override must be available on the value type. A pointer-receiver-only `TableName` method is not picked up here.
 - Map writes do not use struct metadata, so `readonly`, `omitempty`, and field tags do not apply.
 - Mapping is reflection-based. Unmatched columns are ignored, missing columns leave zero values, and scan or type-conversion failures are returned as errors.
 - There is no generic helper for `DELETE`.
-- `Returning(...)` changes the generated SQL for PostgreSQL, but the API does not scan returned rows back into a value.
+- Typed returning helpers are PostgreSQL-only because other supported dialects do not expose a compatible `RETURNING` clause here.
 
 ## Examples
 
@@ -535,6 +650,16 @@ if err != nil {
 }
 ```
 
+### Insert and return a struct
+
+```go
+created, err := orm.InsertReturning[User](ctx, db, User{Name: "sam", Age: 18, Active: true})
+if err != nil {
+    log.Fatal(err)
+}
+_ = created
+```
+
 ### Update selected columns on a struct
 
 ```go
@@ -548,6 +673,24 @@ _, err := orm.Update(
 if err != nil {
     log.Fatal(err)
 }
+```
+
+### Update by scope and return a struct
+
+```go
+updated, err := orm.UpdateByReturning[User](
+    ctx,
+    db,
+    db.Table("users"),
+    map[string]any{"active": true},
+    func(q *query.Query) *query.Query {
+        return q.Where("tenant_id", tenantID).Where("id", id)
+    },
+)
+if err != nil {
+    log.Fatal(err)
+}
+_ = updated
 ```
 
 ### Update a map with `Table(...)`, `PK(...)`, and `WherePK()`

--- a/orm/meta.go
+++ b/orm/meta.go
@@ -112,6 +112,35 @@ func getTypeMeta(t reflect.Type) (*typeMeta, error) {
 	return m, nil
 }
 
+func structColumnNames(t reflect.Type) ([]string, error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("type %s is not struct", t)
+	}
+	cols := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if sf.PkgPath != "" {
+			continue
+		}
+		tag := sf.Tag.Get("db")
+		if tag == "-" {
+			continue
+		}
+		col := ""
+		if tag != "" {
+			col = strings.Split(tag, ",")[0]
+		}
+		if col == "" {
+			col = stringutil.ToSnake(sf.Name)
+		}
+		cols = append(cols, col)
+	}
+	return cols, nil
+}
+
 // ResetMetaCache clears cached reflection metadata. Intended for tests.
 func ResetMetaCache() {
 	metaCache = sync.Map{}

--- a/orm/scope.go
+++ b/orm/scope.go
@@ -87,6 +87,34 @@ func UpdateBy(ctx context.Context, base *query.Query, data any, scopes ...Scope)
 	return q.WithContext(ctx).Update(data)
 }
 
+// UpdateByReturning applies scopes, executes an UPDATE, and scans the Postgres RETURNING row into T.
+func UpdateByReturning[T any](ctx context.Context, db *DB, base *query.Query, data any, scopes ...Scope) (T, error) {
+	var zero T
+	if db == nil {
+		return zero, fmt.Errorf("db is nil")
+	}
+	q, err := scopedQuery(base, scopes...)
+	if err != nil {
+		return zero, err
+	}
+	plan, err := q.PlanUpdate(ctx, data)
+	if err != nil {
+		return zero, err
+	}
+	if err := query.EnsurePlanExecutable(plan); err != nil {
+		return zero, err
+	}
+	cols, err := returningColumnsForQuery[T]()
+	if err != nil {
+		return zero, err
+	}
+	sqlStr, err := appendReturningClause(db.drv.Dialect, plan.SQL, cols)
+	if err != nil {
+		return zero, err
+	}
+	return queryReturningOne[T](ctx, db, sqlStr, plan.Params...)
+}
+
 // DeleteBy applies scopes to base and executes a DELETE using the resulting query.
 func DeleteBy(ctx context.Context, base *query.Query, scopes ...Scope) (sql.Result, error) {
 	q, err := scopedQuery(base, scopes...)

--- a/orm/scope_test.go
+++ b/orm/scope_test.go
@@ -169,6 +169,34 @@ func TestUpdateByAppliesScopes(t *testing.T) {
 	}
 }
 
+func TestUpdateByReturningAppliesScopes(t *testing.T) {
+	ctx := context.Background()
+	db, mock := newReturningMockDB(t)
+
+	mock.ExpectQuery(`UPDATE "users" SET .* WHERE .* RETURNING "id", "name", "age"$`).
+		WithArgs("alice", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(1, "alice", 34))
+
+	row, err := UpdateByReturning[genericWriteUser](
+		ctx,
+		db,
+		db.Table("users"),
+		map[string]any{"name": "alice"},
+		func(q *query.Query) *query.Query {
+			return q.Where("id", 1)
+		},
+	)
+	if err != nil {
+		t.Fatalf("update by returning: %v", err)
+	}
+	if row.ID != 1 || row.Name != "alice" || row.Age != 34 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestDeleteByAppliesScopes(t *testing.T) {
 	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
 

--- a/orm/select.go
+++ b/orm/select.go
@@ -15,7 +15,11 @@ func SelectOne[T any](ctx context.Context, db *DB, q string, args ...any) (T, er
 		return zero, err
 	}
 	defer rows.Close()
+	return scanRowsOne[T](db, rows)
+}
 
+func scanRowsOne[T any](db *DB, rows *sql.Rows) (T, error) {
+	var zero T
 	var t T
 	typ := reflect.TypeOf(t)
 	switch {

--- a/orm/write.go
+++ b/orm/write.go
@@ -15,12 +15,15 @@ import (
 type WriteOpt func(*writeOptions)
 
 type writeOptions struct {
-	cols      map[string]struct{}
-	omit      map[string]struct{}
-	wherePK   bool
-	returning []string
-	table     string
-	pkCols    map[string]struct{}
+	cols               map[string]struct{}
+	omit               map[string]struct{}
+	wherePK            bool
+	returning          []string
+	table              string
+	pkCols             map[string]struct{}
+	conflictCols       []string
+	conflictWhere      string
+	conflictConstraint string
 }
 
 // Columns limits write to specified columns.
@@ -53,6 +56,21 @@ func WherePK() WriteOpt { return func(o *writeOptions) { o.wherePK = true } }
 // Returning specifies columns to return (Postgres only).
 func Returning(cols ...string) WriteOpt { return func(o *writeOptions) { o.returning = cols } }
 
+// ConflictColumns sets the conflict target columns for Upsert.
+func ConflictColumns(cols ...string) WriteOpt {
+	return func(o *writeOptions) { o.conflictCols = append([]string(nil), cols...) }
+}
+
+// ConflictWhere adds a Postgres partial-index predicate to the conflict target.
+func ConflictWhere(predicate string) WriteOpt {
+	return func(o *writeOptions) { o.conflictWhere = predicate }
+}
+
+// ConflictConstraint sets a Postgres named constraint as the conflict target.
+func ConflictConstraint(name string) WriteOpt {
+	return func(o *writeOptions) { o.conflictConstraint = name }
+}
+
 // Table sets table name (required for map writes).
 func Table(name string) WriteOpt { return func(o *writeOptions) { o.table = name } }
 
@@ -82,6 +100,19 @@ func (o *writeOptions) isPK(col string) bool {
 	}
 	_, ok := o.pkCols[col]
 	return ok
+}
+
+func (o *writeOptions) hasConflictTarget() bool {
+	return len(o.conflictCols) > 0 || strings.TrimSpace(o.conflictConstraint) != ""
+}
+
+func (o *writeOptions) isConflictColumn(col string) bool {
+	for _, c := range o.conflictCols {
+		if c == col {
+			return true
+		}
+	}
+	return false
 }
 
 func quote(d driver.Dialect, ident string) string { return d.QuoteIdent(ident) }
@@ -160,9 +191,99 @@ func execReturningRows(ctx context.Context, db *DB, sqlStr string, args ...any) 
 	return returningResult{rowsAffected: count}, nil
 }
 
+func queryReturningOne[T any](ctx context.Context, db *DB, sqlStr string, args ...any) (T, error) {
+	var zero T
+	rows, err := db.queryContextTrusted(ctx, sqlStr, args...)
+	if err != nil {
+		return zero, err
+	}
+	defer rows.Close()
+	return scanRowsOne[T](db, rows)
+}
+
+func ensureReturningColumns[T any](o *writeOptions) error {
+	if len(o.returning) > 0 {
+		return nil
+	}
+	cols, err := returningColumnsForQuery[T]()
+	if err != nil {
+		return err
+	}
+	o.returning = cols
+	return nil
+}
+
+func returningColumnsForQuery[T any]() ([]string, error) {
+	var zero T
+	typ := reflect.TypeOf(zero)
+	if typ == nil {
+		return nil, fmt.Errorf("Returning columns are required for untyped return values")
+	}
+	if isMapStringInterface(typ) {
+		return nil, fmt.Errorf("Returning columns are required for map return values")
+	}
+	cols, err := structColumnNames(typ)
+	if err != nil {
+		return nil, err
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("no columns to return")
+	}
+	return cols, nil
+}
+
+func execWriteStatement(ctx context.Context, db *DB, sqlStr string, args []any, returning bool) (sql.Result, error) {
+	if returning {
+		return execReturningRows(ctx, db, sqlStr, args...)
+	}
+	return db.execContextTrusted(ctx, sqlStr, args...)
+}
+
+func validateWriteRawSQLFragment(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("goquent: raw SQL fragment is required")
+	}
+	if strings.ContainsAny(trimmed, ";\x00") ||
+		strings.Contains(trimmed, "--") ||
+		strings.Contains(trimmed, "/*") ||
+		strings.Contains(trimmed, "*/") {
+		return fmt.Errorf("goquent: raw SQL fragment contains a statement separator or comment")
+	}
+	upper := strings.ToUpper(trimmed)
+	for _, token := range []string{"ALTER", "CREATE", "DELETE", "DROP", "GRANT", "INSERT", "REVOKE", "TRUNCATE", "UPDATE"} {
+		if containsSQLWord(upper, token) {
+			return fmt.Errorf("goquent: raw SQL fragment contains disallowed SQL token %q", token)
+		}
+	}
+	return nil
+}
+
 // Insert inserts v into its table.
 func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
 	o := applyWriteOpts(opts)
+	sqlStr, args, err := buildInsertStatement(db, v, o)
+	if err != nil {
+		return nil, err
+	}
+	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+}
+
+// InsertReturning inserts v and scans the Postgres RETURNING row into T.
+func InsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...WriteOpt) (T, error) {
+	var zero T
+	o := applyWriteOpts(opts)
+	if err := ensureReturningColumns[T](o); err != nil {
+		return zero, err
+	}
+	sqlStr, args, err := buildInsertStatement(db, v, o)
+	if err != nil {
+		return zero, err
+	}
+	return queryReturningOne[T](ctx, db, sqlStr, args...)
+}
+
+func buildInsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	val := reflect.ValueOf(v)
 	typ := val.Type()
 	var table string
@@ -171,7 +292,7 @@ func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 
 	if isMapStringInterface(typ) {
 		if o.table == "" {
-			return nil, fmt.Errorf("Table option required for map writes")
+			return "", nil, fmt.Errorf("Table option required for map writes")
 		}
 		table = o.table
 		iter := val.MapRange()
@@ -195,7 +316,7 @@ func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 		}
 		meta, err := getTypeMeta(typ)
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 		for _, fm := range meta.FieldsByName {
 			if fm.Readonly {
@@ -217,10 +338,10 @@ func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			args = append(args, fv.Interface())
 		}
 	} else {
-		return nil, fmt.Errorf("unsupported type %s", typ)
+		return "", nil, fmt.Errorf("unsupported type %s", typ)
 	}
 	if len(cols) == 0 {
-		return nil, fmt.Errorf("no columns to insert")
+		return "", nil, fmt.Errorf("no columns to insert")
 	}
 	ph := buildPlaceholders(db.drv.Dialect, len(cols), 1)
 	quotedCols := make([]string, len(cols))
@@ -230,19 +351,38 @@ func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
 	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	if len(o.returning) > 0 {
-		return execReturningRows(ctx, db, sqlStr, args...)
-	}
-	return db.execContextTrusted(ctx, sqlStr, args...)
+	return sqlStr, args, nil
 }
 
 // Update updates record v.
 func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
 	o := applyWriteOpts(opts)
+	sqlStr, args, err := buildUpdateStatement(db, v, o)
+	if err != nil {
+		return nil, err
+	}
+	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+}
+
+// UpdateReturning updates v and scans the Postgres RETURNING row into T.
+func UpdateReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...WriteOpt) (T, error) {
+	var zero T
+	o := applyWriteOpts(opts)
+	if err := ensureReturningColumns[T](o); err != nil {
+		return zero, err
+	}
+	sqlStr, args, err := buildUpdateStatement(db, v, o)
+	if err != nil {
+		return zero, err
+	}
+	return queryReturningOne[T](ctx, db, sqlStr, args...)
+}
+
+func buildUpdateStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	if !o.wherePK {
-		return nil, fmt.Errorf("Update[T] without WherePK is not allowed")
+		return "", nil, fmt.Errorf("Update[T] without WherePK is not allowed")
 	}
 	val := reflect.ValueOf(v)
 	typ := val.Type()
@@ -254,10 +394,10 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 
 	if isMapStringInterface(typ) {
 		if o.table == "" {
-			return nil, fmt.Errorf("Table option required for map writes")
+			return "", nil, fmt.Errorf("Table option required for map writes")
 		}
 		if len(o.pkCols) == 0 {
-			return nil, fmt.Errorf("WherePK for map writes requires PK columns via PK option")
+			return "", nil, fmt.Errorf("WherePK for map writes requires PK columns via PK option")
 		}
 		table = o.table
 		iter := val.MapRange()
@@ -284,7 +424,7 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 		}
 		for pk := range o.pkCols {
 			if !seen[pk] {
-				return nil, fmt.Errorf("WherePK requires pk column %s", pk)
+				return "", nil, fmt.Errorf("WherePK requires pk column %s", pk)
 			}
 		}
 	} else if typ.Kind() == reflect.Struct {
@@ -294,7 +434,7 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 		}
 		meta, err := getTypeMeta(typ)
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 		for _, fm := range meta.FieldsByName {
 			fv := val.FieldByIndex(fm.IndexPath)
@@ -321,13 +461,13 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			setArgs = append(setArgs, fv.Interface())
 		}
 	} else {
-		return nil, fmt.Errorf("unsupported type %s", typ)
+		return "", nil, fmt.Errorf("unsupported type %s", typ)
 	}
 	if len(whereCols) == 0 {
-		return nil, fmt.Errorf("WherePK requires pk values")
+		return "", nil, fmt.Errorf("WherePK requires pk values")
 	}
 	if len(setCols) == 0 {
-		return nil, fmt.Errorf("no columns to update")
+		return "", nil, fmt.Errorf("no columns to update")
 	}
 	setParts := make([]string, len(setCols))
 	for i, col := range setCols {
@@ -341,19 +481,38 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE %s", quote(db.drv.Dialect, table), strings.Join(setParts, ", "), strings.Join(whereParts, " AND "))
 	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	if len(o.returning) > 0 {
-		return execReturningRows(ctx, db, sqlStr, args...)
-	}
-	return db.execContextTrusted(ctx, sqlStr, args...)
+	return sqlStr, args, nil
 }
 
 // Upsert inserts or updates v using primary keys.
 func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
 	o := applyWriteOpts(opts)
-	if !o.wherePK {
-		return nil, fmt.Errorf("Upsert[T] without WherePK is not allowed")
+	sqlStr, args, err := buildUpsertStatement(db, v, o)
+	if err != nil {
+		return nil, err
+	}
+	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+}
+
+// UpsertReturning upserts v and scans the Postgres RETURNING row into T.
+func UpsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...WriteOpt) (T, error) {
+	var zero T
+	o := applyWriteOpts(opts)
+	if err := ensureReturningColumns[T](o); err != nil {
+		return zero, err
+	}
+	sqlStr, args, err := buildUpsertStatement(db, v, o)
+	if err != nil {
+		return zero, err
+	}
+	return queryReturningOne[T](ctx, db, sqlStr, args...)
+}
+
+func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
+	if !o.wherePK && !o.hasConflictTarget() {
+		return "", nil, fmt.Errorf("Upsert[T] requires WherePK, ConflictColumns, or ConflictConstraint")
 	}
 	val := reflect.ValueOf(v)
 	typ := val.Type()
@@ -361,14 +520,13 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	var cols []string
 	var args []any
 	var pkCols []string
-	var updateCols []string
 
 	if isMapStringInterface(typ) {
 		if o.table == "" {
-			return nil, fmt.Errorf("Table option required for map writes")
+			return "", nil, fmt.Errorf("Table option required for map writes")
 		}
-		if len(o.pkCols) == 0 {
-			return nil, fmt.Errorf("WherePK for map writes requires PK columns via PK option")
+		if o.wherePK && len(o.pkCols) == 0 {
+			return "", nil, fmt.Errorf("WherePK for map writes requires PK columns via PK option")
 		}
 		table = o.table
 		iter := val.MapRange()
@@ -379,6 +537,11 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			seen[col] = true
 			if o.isPK(col) {
 				pkCols = append(pkCols, col)
+				cols = append(cols, col)
+				args = append(args, fv)
+				continue
+			}
+			if o.isConflictColumn(col) {
 				cols = append(cols, col)
 				args = append(args, fv)
 				continue
@@ -394,14 +557,11 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			cols = append(cols, col)
 			args = append(args, fv)
 		}
-		for pk := range o.pkCols {
-			if !seen[pk] {
-				return nil, fmt.Errorf("WherePK requires pk column %s", pk)
-			}
-		}
-		for _, c := range cols {
-			if !o.isPK(c) {
-				updateCols = append(updateCols, c)
+		if o.wherePK {
+			for pk := range o.pkCols {
+				if !seen[pk] {
+					return "", nil, fmt.Errorf("WherePK requires pk column %s", pk)
+				}
 			}
 		}
 	} else if typ.Kind() == reflect.Struct {
@@ -411,12 +571,17 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 		}
 		meta, err := getTypeMeta(typ)
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 		for _, fm := range meta.FieldsByName {
 			fv := val.FieldByIndex(fm.IndexPath)
 			if fm.PK {
 				pkCols = append(pkCols, fm.Col)
+				cols = append(cols, fm.Col)
+				args = append(args, fv.Interface())
+				continue
+			}
+			if o.isConflictColumn(fm.Col) {
 				cols = append(cols, fm.Col)
 				args = append(args, fv.Interface())
 				continue
@@ -438,23 +603,17 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			cols = append(cols, fm.Col)
 			args = append(args, fv.Interface())
 		}
-		for _, c := range cols {
-			foundPK := false
-			for _, pk := range pkCols {
-				if c == pk {
-					foundPK = true
-					break
-				}
-			}
-			if !foundPK {
-				updateCols = append(updateCols, c)
-			}
-		}
 	} else {
-		return nil, fmt.Errorf("unsupported type %s", typ)
+		return "", nil, fmt.Errorf("unsupported type %s", typ)
 	}
-	if len(pkCols) == 0 {
-		return nil, fmt.Errorf("WherePK requires pk values")
+	if o.wherePK && len(pkCols) == 0 {
+		return "", nil, fmt.Errorf("WherePK requires pk values")
+	}
+	if len(cols) == 0 {
+		return "", nil, fmt.Errorf("no columns to insert")
+	}
+	if err := ensureConflictColumnsPresent(o.conflictCols, cols); err != nil {
+		return "", nil, err
 	}
 	ph := buildPlaceholders(db.drv.Dialect, len(cols), 1)
 	quotedCols := make([]string, len(cols))
@@ -462,8 +621,13 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 		quotedCols[i] = quote(db.drv.Dialect, c)
 	}
 	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	targetCols := conflictTargetColumns(o, pkCols)
+	updateCols := upsertUpdateColumns(cols, targetCols)
 	switch db.drv.Dialect.(type) {
 	case driver.MySQLDialect:
+		if strings.TrimSpace(o.conflictWhere) != "" || strings.TrimSpace(o.conflictConstraint) != "" {
+			return "", nil, fmt.Errorf("ConflictWhere and ConflictConstraint are not supported on dialect: %T", db.drv.Dialect)
+		}
 		if len(updateCols) > 0 {
 			assigns := make([]string, len(updateCols))
 			for i, c := range updateCols {
@@ -474,28 +638,111 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 			sqlStr = strings.Replace(sqlStr, "INSERT", "INSERT IGNORE", 1)
 		}
 	case driver.PostgresDialect:
-		quotedPK := make([]string, len(pkCols))
-		for i, c := range pkCols {
-			quotedPK[i] = quote(db.drv.Dialect, c)
+		target, err := postgresConflictTarget(db.drv.Dialect, targetCols, o)
+		if err != nil {
+			return "", nil, err
 		}
 		if len(updateCols) > 0 {
 			assigns := make([]string, len(updateCols))
 			for i, c := range updateCols {
 				assigns[i] = fmt.Sprintf("%s=EXCLUDED.%s", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c))
 			}
-			sqlStr += fmt.Sprintf(" ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(quotedPK, ", "), strings.Join(assigns, ", "))
+			sqlStr += fmt.Sprintf(" ON CONFLICT %s DO UPDATE SET %s", target, strings.Join(assigns, ", "))
 		} else {
-			sqlStr += fmt.Sprintf(" ON CONFLICT (%s) DO NOTHING", strings.Join(quotedPK, ", "))
+			sqlStr += fmt.Sprintf(" ON CONFLICT %s DO NOTHING", target)
 		}
 	default:
-		return nil, fmt.Errorf("upsert not supported on dialect: %T", db.drv.Dialect)
+		return "", nil, fmt.Errorf("upsert not supported on dialect: %T", db.drv.Dialect)
 	}
 	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	if len(o.returning) > 0 {
-		return execReturningRows(ctx, db, sqlStr, args...)
+	return sqlStr, args, nil
+}
+
+func conflictTargetColumns(o *writeOptions, pkCols []string) []string {
+	if len(o.conflictCols) > 0 {
+		return append([]string(nil), o.conflictCols...)
 	}
-	return db.execContextTrusted(ctx, sqlStr, args...)
+	return append([]string(nil), pkCols...)
+}
+
+func upsertUpdateColumns(cols []string, targetCols []string) []string {
+	target := make(map[string]struct{}, len(targetCols))
+	for _, col := range targetCols {
+		target[col] = struct{}{}
+	}
+	updateCols := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if _, ok := target[col]; ok {
+			continue
+		}
+		updateCols = append(updateCols, col)
+	}
+	return updateCols
+}
+
+func ensureConflictColumnsPresent(targetCols []string, cols []string) error {
+	if len(targetCols) == 0 {
+		return nil
+	}
+	present := make(map[string]struct{}, len(cols))
+	for _, col := range cols {
+		present[col] = struct{}{}
+	}
+	for _, col := range targetCols {
+		if _, ok := present[col]; !ok {
+			return fmt.Errorf("ConflictColumns requires column %s", col)
+		}
+	}
+	return nil
+}
+
+func postgresConflictTarget(d driver.Dialect, cols []string, o *writeOptions) (string, error) {
+	constraint := strings.TrimSpace(o.conflictConstraint)
+	predicate := strings.TrimSpace(o.conflictWhere)
+	if constraint != "" {
+		if len(o.conflictCols) > 0 {
+			return "", fmt.Errorf("ConflictConstraint cannot be combined with ConflictColumns")
+		}
+		if predicate != "" {
+			return "", fmt.Errorf("ConflictConstraint cannot be combined with ConflictWhere")
+		}
+		return "ON CONSTRAINT " + quote(d, constraint), nil
+	}
+	if len(cols) == 0 {
+		return "", fmt.Errorf("Postgres upsert requires ConflictColumns or WherePK primary key columns")
+	}
+	quoted := make([]string, len(cols))
+	for i, col := range cols {
+		quoted[i] = quote(d, col)
+	}
+	target := "(" + strings.Join(quoted, ", ") + ")"
+	if predicate != "" {
+		if err := validateWriteRawSQLFragment(predicate); err != nil {
+			return "", err
+		}
+		target += " WHERE " + predicate
+	}
+	return target, nil
+}
+
+func containsSQLWord(upperSQL, token string) bool {
+	for i := 0; i+len(token) <= len(upperSQL); i++ {
+		if upperSQL[i:i+len(token)] != token {
+			continue
+		}
+		beforeOK := i == 0 || !isSQLWordByte(upperSQL[i-1])
+		after := i + len(token)
+		afterOK := after >= len(upperSQL) || !isSQLWordByte(upperSQL[after])
+		if beforeOK && afterOK {
+			return true
+		}
+	}
+	return false
+}
+
+func isSQLWordByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }

--- a/orm/write_test.go
+++ b/orm/write_test.go
@@ -198,6 +198,51 @@ func TestInsertReturningPostgresAddsClause(t *testing.T) {
 	}
 }
 
+func TestInsertReturningTypedInfersColumns(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`INSERT INTO "users".*RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(1, "alice", 30))
+
+	row, err := InsertReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{Name: "alice"},
+		Columns("name"),
+	)
+	if err != nil {
+		t.Fatalf("insert returning typed: %v", err)
+	}
+	if row.ID != 1 || row.Name != "alice" || row.Age != 30 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestInsertReturningMapUsesExplicitColumns(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`INSERT INTO "users".*RETURNING "id", "name"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "alice"))
+
+	row, err := InsertReturning[map[string]any](
+		context.Background(),
+		db,
+		map[string]any{"name": "alice"},
+		Table("users"),
+		Returning("id", "name"),
+	)
+	if err != nil {
+		t.Fatalf("insert returning map: %v", err)
+	}
+	if row["id"] != int64(1) || row["name"] != "alice" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestUpdateReturningPostgresAddsClause(t *testing.T) {
 	db, mock := newReturningMockDB(t)
 	mock.ExpectQuery(`UPDATE "users" SET .* RETURNING "id", "name"$`).
@@ -216,6 +261,29 @@ func TestUpdateReturningPostgresAddsClause(t *testing.T) {
 	}
 	if aff, err := res.RowsAffected(); err != nil || aff != 1 {
 		t.Fatalf("expected rows affected 1, got %d err=%v", aff, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpdateReturningTypedInfersColumns(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`UPDATE "users" SET .* RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(3, "alice", 31))
+
+	row, err := UpdateReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 3, Name: "alice"},
+		Columns("name"),
+		WherePK(),
+	)
+	if err != nil {
+		t.Fatalf("update returning typed: %v", err)
+	}
+	if row.ID != 3 || row.Name != "alice" || row.Age != 31 {
+		t.Fatalf("unexpected row: %+v", row)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -242,5 +310,72 @@ func TestUpsertReturningPostgresAddsClause(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpsertReturningTypedInfersColumns(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`INSERT INTO "users".*ON CONFLICT \("id"\) DO UPDATE SET .* RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(5, "alice", 32))
+
+	row, err := UpsertReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 5, Name: "alice"},
+		WherePK(),
+	)
+	if err != nil {
+		t.Fatalf("upsert returning typed: %v", err)
+	}
+	if row.ID != 5 || row.Name != "alice" || row.Age != 32 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpsertPostgresConflictWhere(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{
+			"id":              "audit-1",
+			"tenant_id":       "tenant-1",
+			"idempotency_key": "idem-1",
+			"payload_json":    "{}",
+		},
+		Table("ai_audit_logs"),
+		ConflictColumns("tenant_id", "idempotency_key"),
+		ConflictWhere("idempotency_key <> ''"),
+	)
+	if err != nil {
+		t.Fatalf("upsert conflict where: %v", err)
+	}
+	if !strings.Contains(exec.query, `ON CONFLICT ("tenant_id", "idempotency_key") WHERE idempotency_key <> '' DO UPDATE SET`) {
+		t.Fatalf("expected partial-index conflict target, got: %s", exec.query)
+	}
+	if strings.Contains(exec.query, `"tenant_id"=EXCLUDED."tenant_id"`) || strings.Contains(exec.query, `"idempotency_key"=EXCLUDED."idempotency_key"`) {
+		t.Fatalf("conflict columns should not be updated: %s", exec.query)
+	}
+}
+
+func TestUpsertPostgresConflictConstraint(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{"name": "alice", "age": 30},
+		Table("users"),
+		ConflictConstraint("users_name_key"),
+	)
+	if err != nil {
+		t.Fatalf("upsert conflict constraint: %v", err)
+	}
+	if !strings.Contains(exec.query, `ON CONFLICT ON CONSTRAINT "users_name_key" DO UPDATE SET`) {
+		t.Fatalf("expected named constraint conflict target, got: %s", exec.query)
 	}
 }


### PR DESCRIPTION
**Summary**
This PR improves goquent 0.5.1 ergonomics for multi-tenant CRUD adapters while keeping existing write APIs backward compatible.

- Added typed `InsertReturning[T]`, `UpdateReturning[T]`, and `UpsertReturning[T]` helpers that scan `RETURNING` rows directly into structs or maps.
- Added `UpdateByReturning[T]` for scoped updates that need to return the updated row without a follow-up select.
- Added `ConflictColumns`, `ConflictWhere`, and `ConflictConstraint` write options so `Upsert` can target partial unique indexes and named constraints.
- Preserved existing `Insert`, `Update`, `Upsert`, and `Returning` behavior, including `sql.Result` return values.
- Documented recommended handling for SQL `numeric` / `decimal` scan targets.
- Validated the new API with representative codraft client repository create/update paths.

**Testing**
- `GOCACHE=/tmp/go-build-cache go test ./orm -count=1`
- `GOCACHE=/tmp/go-build-cache go test ./cmd/goquent ./orm/... -count=1`
- `GOCACHE=/tmp/go-build-cache go test ./... -count=1` in `codraft/apps/api`
