### PR TITLE
Add safer upsert controls and tenant/raw predicate helpers

### DIFF
--- a/docs/orm/generic-crud.md
+++ b/docs/orm/generic-crud.md
@@ -88,6 +88,16 @@ users, err := orm.SelectAllBy[User](
 _, err = orm.UpdateBy(ctx, db.Table("users"), map[string]any{"age": 55}, WithProfile(), BioLike("%go%"))
 updated, err := orm.UpdateByReturning[User](ctx, db, db.Table("users"), map[string]any{"age": 55}, WithProfile(), BioLike("%go%"))
 _, err = orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"))
+
+tenantUsers, err := orm.SelectAllBy[User](
+    ctx,
+    db,
+    db.Model(&User{}),
+    orm.TenantScope(tenantID),
+    func(q *query.Query) *query.Query {
+        return q.Select("id", "name", "age").Limit(100)
+    },
+)
 ```
 
 ## Read API
@@ -277,6 +287,43 @@ If there are no non-primary-key columns left to update after filtering, the help
 - MySQL: `INSERT IGNORE`
 - PostgreSQL: `ON CONFLICT (...) DO NOTHING`
 
+When the insert payload contains columns that must not be updated on conflict, keep those columns in the insert side and pass `UpdateColumns(...)` for the conflict update side:
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{
+        "id":               fieldID,
+        "tenant_id":        tenantID,
+        "form_instance_id": formID,
+        "field_key":        "weekly_hours",
+        "value_text":       "40",
+        "needs_update":     false,
+    },
+    orm.Table("form_fields"),
+    orm.ConflictColumns("tenant_id", "form_instance_id", "field_key"),
+    orm.UpdateColumns("value_text", "needs_update"),
+)
+```
+
+For append-only or idempotency tables where the existing row should not be touched, use `ConflictDoNothing()`:
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{
+        "tenant_id":       tenantID,
+        "idempotency_key": key,
+        "payload_json":    payload,
+    },
+    orm.Table("submission_attempts"),
+    orm.ConflictColumns("tenant_id", "idempotency_key"),
+    orm.ConflictDoNothing(),
+)
+```
+
 ```go
 _, err := orm.Upsert(
     ctx,
@@ -437,6 +484,38 @@ _, err := orm.Upsert(
 
 `ConflictConstraint` builds `ON CONFLICT ON CONSTRAINT ...` for PostgreSQL named unique constraints. It cannot be combined with `ConflictColumns(...)` or `ConflictWhere(...)`.
 
+### `UpdateColumns(...)`
+
+`UpdateColumns` limits only the conflict update side of `Upsert` and `UpsertReturning`. The insert side still uses `Columns(...)`, `Omit(...)`, and the required primary-key or conflict columns.
+
+Use it when an insert payload includes application-generated IDs or immutable audit columns that must be written only on the first insert:
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    formField,
+    orm.ConflictColumns("tenant_id", "form_instance_id", "field_key"),
+    orm.UpdateColumns("value_text", "value_json", "attachment_required", "needs_update"),
+)
+```
+
+Every column named in `UpdateColumns` must also be present in the insert column set, because PostgreSQL `EXCLUDED` and MySQL `VALUES(...)` read from the attempted insert row.
+
+### `ConflictDoNothing()`
+
+`ConflictDoNothing` forces a no-op conflict action even when the insert payload contains non-conflict columns.
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    auditEvent,
+    orm.ConflictColumns("tenant_id", "idempotency_key"),
+    orm.ConflictDoNothing(),
+)
+```
+
 ### `Table(...)`
 
 `Table` overrides the inferred table name for struct writes and is required for map writes.
@@ -554,6 +633,21 @@ activeDevelopers := orm.ComposeScopes(
     WithProfile(),
     BioLike("%developer%"),
 )
+```
+
+### `TenantScope(...)`
+
+`TenantScope` is a small reusable scope for the common `tenant_id = ?` predicate. Pass a custom column name when the table uses a different tenant boundary column.
+
+```go
+tenantDocs := orm.ComposeScopes(
+    orm.TenantScope(tenantID),
+    func(q *query.Query) *query.Query {
+        return q.WhereNull("archived_at")
+    },
+)
+
+scopeBindings := orm.TenantScope(tenantID, "scope_tenant_id")
 ```
 
 ### `SelectOneBy[T]` and `SelectAllBy[T]`

--- a/orm/query/plan_test.go
+++ b/orm/query/plan_test.go
@@ -202,3 +202,22 @@ func TestPlanParamsOrderingAndInjectionRegression(t *testing.T) {
 		t.Fatalf("placeholder count=%d sql=%q", got, plan.SQL)
 	}
 }
+
+func TestWhereRawNoArgsPlan(t *testing.T) {
+	plan, err := newPlanTestQuery(&recordingExec{}).
+		WhereRawNoArgs("deleted_at IS NULL").
+		Limit(1).
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(plan.SQL, "deleted_at IS NULL") {
+		t.Fatalf("expected raw predicate in SQL, got %q", plan.SQL)
+	}
+	if len(plan.Params) != 0 {
+		t.Fatalf("expected no params, got %#v", plan.Params)
+	}
+	if len(plan.Predicates) != 1 || plan.Predicates[0].Raw != "deleted_at IS NULL" {
+		t.Fatalf("predicates=%#v", plan.Predicates)
+	}
+}

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -693,6 +693,11 @@ func (q *Query) WhereRaw(raw string, vals map[string]any) *Query {
 	return q
 }
 
+// WhereRawNoArgs appends a raw WHERE condition that has no placeholders.
+func (q *Query) WhereRawNoArgs(raw string) *Query {
+	return q.WhereRaw(raw, map[string]any{})
+}
+
 // OrWhereRaw appends raw OR WHERE condition.
 func (q *Query) OrWhereRaw(raw string, vals map[string]any) *Query {
 	if q.err != nil {
@@ -704,6 +709,11 @@ func (q *Query) OrWhereRaw(raw string, vals map[string]any) *Query {
 	}
 	q.builder.OrWhereRaw(raw, vals)
 	return q
+}
+
+// OrWhereRawNoArgs appends a raw OR WHERE condition that has no placeholders.
+func (q *Query) OrWhereRawNoArgs(raw string) *Query {
+	return q.OrWhereRaw(raw, map[string]any{})
 }
 
 // SafeWhereRaw appends a raw WHERE condition ensuring a values map is always used.

--- a/orm/scope.go
+++ b/orm/scope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/faciam-dev/goquent/orm/query"
 )
@@ -29,6 +30,19 @@ func ApplyScopes(q *query.Query, scopes ...Scope) *query.Query {
 func ComposeScopes(scopes ...Scope) Scope {
 	return func(q *query.Query) *query.Query {
 		return ApplyScopes(q, scopes...)
+	}
+}
+
+// TenantScope adds a tenant filter scope. The default column is tenant_id.
+func TenantScope(tenantID any, column ...string) Scope {
+	col := "tenant_id"
+	if len(column) > 0 {
+		if trimmed := strings.TrimSpace(column[0]); trimmed != "" {
+			col = trimmed
+		}
+	}
+	return func(q *query.Query) *query.Query {
+		return q.Where(col, tenantID)
 	}
 }
 

--- a/orm/scope_test.go
+++ b/orm/scope_test.go
@@ -115,6 +115,40 @@ func TestComposeScopesSupportsGroupsAndExists(t *testing.T) {
 	}
 }
 
+func TestTenantScopeAddsDefaultTenantFilter(t *testing.T) {
+	db, _ := newScopeMockDB(t, driver.MySQLDialect{})
+
+	q := ApplyScopes(db.Table("documents"), TenantScope("tenant-1"))
+	sqlStr, args, err := q.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if !strings.Contains(sqlStr, "WHERE `tenant_id` = ?") {
+		t.Fatalf("expected default tenant filter, got: %s", sqlStr)
+	}
+	if len(args) != 1 || args[0] != "tenant-1" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
+func TestTenantScopeAllowsCustomTenantColumn(t *testing.T) {
+	db, _ := newScopeMockDB(t, driver.PostgresDialect{})
+
+	q := ApplyScopes(db.Table("role_bindings"), TenantScope("tenant-1", "scope_tenant_id"))
+	sqlStr, args, err := q.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if !strings.Contains(sqlStr, `WHERE "scope_tenant_id" = $1`) {
+		t.Fatalf("expected custom tenant filter, got: %s", sqlStr)
+	}
+	if len(args) != 1 || args[0] != "tenant-1" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
 func TestSelectAllByBuildsFromScopedQuery(t *testing.T) {
 	ctx := context.Background()
 	db, mock := newScopeMockDB(t, driver.MySQLDialect{})

--- a/orm/write.go
+++ b/orm/write.go
@@ -24,6 +24,8 @@ type writeOptions struct {
 	conflictCols       []string
 	conflictWhere      string
 	conflictConstraint string
+	upsertUpdateCols   []string
+	hasUpsertUpdates   bool
 }
 
 // Columns limits write to specified columns.
@@ -69,6 +71,23 @@ func ConflictWhere(predicate string) WriteOpt {
 // ConflictConstraint sets a Postgres named constraint as the conflict target.
 func ConflictConstraint(name string) WriteOpt {
 	return func(o *writeOptions) { o.conflictConstraint = name }
+}
+
+// UpdateColumns limits the conflict UPDATE side of Upsert/UpsertReturning.
+// The insert side still uses Columns/Omit plus required conflict or primary-key columns.
+func UpdateColumns(cols ...string) WriteOpt {
+	return func(o *writeOptions) {
+		o.upsertUpdateCols = append([]string(nil), cols...)
+		o.hasUpsertUpdates = true
+	}
+}
+
+// ConflictDoNothing makes Upsert/UpsertReturning use a no-op conflict action.
+func ConflictDoNothing() WriteOpt {
+	return func(o *writeOptions) {
+		o.upsertUpdateCols = nil
+		o.hasUpsertUpdates = true
+	}
 }
 
 // Table sets table name (required for map writes).
@@ -622,7 +641,10 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	}
 	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
 	targetCols := conflictTargetColumns(o, pkCols)
-	updateCols := upsertUpdateColumns(cols, targetCols)
+	updateCols, err := upsertUpdateColumns(cols, targetCols, o)
+	if err != nil {
+		return "", nil, err
+	}
 	switch db.drv.Dialect.(type) {
 	case driver.MySQLDialect:
 		if strings.TrimSpace(o.conflictWhere) != "" || strings.TrimSpace(o.conflictConstraint) != "" {
@@ -654,7 +676,7 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	default:
 		return "", nil, fmt.Errorf("upsert not supported on dialect: %T", db.drv.Dialect)
 	}
-	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
+	sqlStr, err = appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
 		return "", nil, err
 	}
@@ -668,7 +690,14 @@ func conflictTargetColumns(o *writeOptions, pkCols []string) []string {
 	return append([]string(nil), pkCols...)
 }
 
-func upsertUpdateColumns(cols []string, targetCols []string) []string {
+func upsertUpdateColumns(cols []string, targetCols []string, o *writeOptions) ([]string, error) {
+	if o.hasUpsertUpdates {
+		updateCols := dedupeColumns(o.upsertUpdateCols)
+		if err := ensureUpsertUpdateColumnsPresent(updateCols, cols); err != nil {
+			return nil, err
+		}
+		return updateCols, nil
+	}
 	target := make(map[string]struct{}, len(targetCols))
 	for _, col := range targetCols {
 		target[col] = struct{}{}
@@ -680,7 +709,24 @@ func upsertUpdateColumns(cols []string, targetCols []string) []string {
 		}
 		updateCols = append(updateCols, col)
 	}
-	return updateCols
+	return updateCols, nil
+}
+
+func dedupeColumns(cols []string) []string {
+	seen := make(map[string]struct{}, len(cols))
+	out := make([]string, 0, len(cols))
+	for _, col := range cols {
+		key := strings.TrimSpace(col)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
 }
 
 func ensureConflictColumnsPresent(targetCols []string, cols []string) error {
@@ -694,6 +740,22 @@ func ensureConflictColumnsPresent(targetCols []string, cols []string) error {
 	for _, col := range targetCols {
 		if _, ok := present[col]; !ok {
 			return fmt.Errorf("ConflictColumns requires column %s", col)
+		}
+	}
+	return nil
+}
+
+func ensureUpsertUpdateColumnsPresent(updateCols []string, insertCols []string) error {
+	if len(updateCols) == 0 {
+		return nil
+	}
+	present := make(map[string]struct{}, len(insertCols))
+	for _, col := range insertCols {
+		present[col] = struct{}{}
+	}
+	for _, col := range updateCols {
+		if _, ok := present[col]; !ok {
+			return fmt.Errorf("UpdateColumns requires inserted column %s", col)
 		}
 	}
 	return nil

--- a/orm/write_test.go
+++ b/orm/write_test.go
@@ -362,6 +362,85 @@ func TestUpsertPostgresConflictWhere(t *testing.T) {
 	}
 }
 
+func TestUpsertPostgresUpdateColumnsSeparatesInsertAndUpdate(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{
+			"id":               "field-1",
+			"tenant_id":        "tenant-1",
+			"form_instance_id": "form-1",
+			"field_key":        "weekly_hours",
+			"value_text":       "40",
+			"needs_update":     false,
+		},
+		Table("form_fields"),
+		ConflictColumns("tenant_id", "form_instance_id", "field_key"),
+		UpdateColumns("value_text", "needs_update"),
+	)
+	if err != nil {
+		t.Fatalf("upsert update columns: %v", err)
+	}
+	if !strings.Contains(exec.query, `"id"`) {
+		t.Fatalf("expected insert-only id column to be present, got: %s", exec.query)
+	}
+	if !strings.Contains(exec.query, `"value_text"=EXCLUDED."value_text"`) || !strings.Contains(exec.query, `"needs_update"=EXCLUDED."needs_update"`) {
+		t.Fatalf("expected explicit update columns, got: %s", exec.query)
+	}
+	for _, col := range []string{`"id"=EXCLUDED."id"`, `"tenant_id"=EXCLUDED."tenant_id"`, `"form_instance_id"=EXCLUDED."form_instance_id"`, `"field_key"=EXCLUDED."field_key"`} {
+		if strings.Contains(exec.query, col) {
+			t.Fatalf("column %s should not be updated: %s", col, exec.query)
+		}
+	}
+}
+
+func TestUpsertConflictDoNothing(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{
+			"tenant_id":       "tenant-1",
+			"idempotency_key": "idem-1",
+			"payload_json":    "{}",
+		},
+		Table("submission_attempts"),
+		ConflictColumns("tenant_id", "idempotency_key"),
+		ConflictDoNothing(),
+	)
+	if err != nil {
+		t.Fatalf("upsert do nothing: %v", err)
+	}
+	if !strings.Contains(exec.query, `ON CONFLICT ("tenant_id", "idempotency_key") DO NOTHING`) {
+		t.Fatalf("expected DO NOTHING conflict action, got: %s", exec.query)
+	}
+	if strings.Contains(exec.query, "DO UPDATE") {
+		t.Fatalf("expected no conflict update, got: %s", exec.query)
+	}
+}
+
+func TestUpsertUpdateColumnsRequireInsertedColumn(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{
+			"tenant_id": "tenant-1",
+			"field_key": "weekly_hours",
+		},
+		Table("form_fields"),
+		ConflictColumns("tenant_id", "field_key"),
+		UpdateColumns("value_text"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "UpdateColumns requires inserted column value_text") {
+		t.Fatalf("expected missing update column error, got: %v", err)
+	}
+}
+
 func TestUpsertPostgresConflictConstraint(t *testing.T) {
 	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
 

--- a/tests/query_extra_test.go
+++ b/tests/query_extra_test.go
@@ -30,6 +30,23 @@ func TestWhereNullAndNotNull(t *testing.T) {
 	}
 }
 
+func TestWhereRawNoArgs(t *testing.T) {
+	db := setupDB(t)
+	defer db.Close()
+
+	if _, err := db.Table("users").Insert(map[string]any{"name": "raw-null", "age": nil}); err != nil {
+		t.Fatalf("insert null user: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("users").WhereRawNoArgs("age IS NULL").FirstMap(&row); err != nil {
+		t.Fatalf("where raw no args: %v", err)
+	}
+	if row["name"] != "raw-null" {
+		t.Errorf("expected raw-null, got %v", row["name"])
+	}
+}
+
 func TestWhereBetween(t *testing.T) {
 	db := setupDB(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary

- Add `UpdateColumns(...)` for upserts so insert-only columns can be preserved while limiting conflict updates.
- Add `ConflictDoNothing()` for append-only and idempotency-style writes.
- Add `WhereRawNoArgs` / `OrWhereRawNoArgs` for constant predicates without empty value maps.
- Add `TenantScope(...)` as a reusable tenant filter scope.
- Document the new upsert and tenant-scope patterns in the generic CRUD guide.

## Tests

- `go test -count=1 ./orm ./orm/query ./cmd/goquent`
- `go test -count=1 -run TestWhereRawNoArgs ./tests`

Note: `go test ./...` was attempted, but the local PostgreSQL test setup failed with `pq: password authentication failed for user "postgres"`.