### PR TITLE
Release 0.5.3: tighten select safety and add idempotent write helpers

### DIFF
--- a/docs/orm/generic-crud.md
+++ b/docs/orm/generic-crud.md
@@ -362,6 +362,26 @@ _, err := orm.Upsert(
 )
 ```
 
+For PostgreSQL expression indexes, use `ConflictTargetRaw(...)`. This is an
+explicit raw escape hatch for the conflict target only; prefer
+`ConflictColumns(...)`, `ConflictWhere(...)`, or `ConflictConstraint(...)`
+when they can express the index.
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    map[string]any{
+        "tenant_id":      tenantID,
+        "target_node_id": targetNodeID,
+        "payload_json":   payload,
+    },
+    orm.Table("citation_links"),
+    orm.ConflictTargetRaw(`("tenant_id", COALESCE("target_node_id", '')) WHERE "active"`),
+    orm.ConflictDoNothing(),
+)
+```
+
 ### Typed returning helpers
 
 `InsertReturning[T]`, `UpdateReturning[T]`, and `UpsertReturning[T]` execute the same generated write statements as `Insert`, `Update`, and `Upsert`, but scan the PostgreSQL `RETURNING` row into `T`.
@@ -391,6 +411,33 @@ updated, err := orm.UpdateByReturning[User](
 ```
 
 Map return values cannot infer a column list. For `InsertReturning`, `UpdateReturning`, and `UpsertReturning`, pass `Returning(...)` when the destination is `map[string]any`. `UpdateByReturning` currently infers columns from a struct destination.
+
+### Insert-once returning
+
+`InsertOnceReturning[T]` is for append-only/idempotency tables. It attempts
+`ON CONFLICT DO NOTHING RETURNING ...`. If the row was inserted, the second
+return value is `true`. If the conflict path returns no row, goquent looks up
+the existing row by `ConflictColumns(...)` or `WherePK()`.
+
+```go
+attempt, inserted, err := orm.InsertOnceReturning[SubmissionAttemptRow](
+    ctx,
+    db,
+    map[string]any{
+        "tenant_id":       tenantID,
+        "idempotency_key": key,
+        "payload_json":    payload,
+    },
+    orm.Table("submission_attempts"),
+    orm.ConflictColumns("tenant_id", "idempotency_key"),
+    orm.Returning("id", "tenant_id", "idempotency_key", "payload_json"),
+)
+_ = inserted
+_ = attempt
+```
+
+For expression-only raw conflict targets, also provide `ConflictColumns(...)`
+or `WherePK()` when you need the existing-row lookup.
 
 ## Write options
 
@@ -483,6 +530,24 @@ _, err := orm.Upsert(
 ### `ConflictConstraint(...)`
 
 `ConflictConstraint` builds `ON CONFLICT ON CONSTRAINT ...` for PostgreSQL named unique constraints. It cannot be combined with `ConflictColumns(...)` or `ConflictWhere(...)`.
+
+### `ConflictTargetRaw(...)`
+
+`ConflictTargetRaw` supplies the PostgreSQL `ON CONFLICT` target literally. Use
+it for expression indexes that cannot be represented as plain columns.
+
+```go
+_, err := orm.Upsert(
+    ctx,
+    db,
+    row,
+    orm.ConflictTargetRaw(`("tenant_id", lower("external_key")) WHERE "active"`),
+    orm.ConflictDoNothing(),
+)
+```
+
+It cannot be combined with `ConflictColumns(...)`, `ConflictWhere(...)`, or
+`ConflictConstraint(...)`.
 
 ### `UpdateColumns(...)`
 
@@ -598,6 +663,34 @@ if err := tx.Commit(); err != nil {
 
 The same pattern works with `db.Begin()`.
 
+## JSON, nullable values, and projections
+
+Use `JSONField[T]` in persistence rows for JSON/JSONB columns when you want
+typed scan and value behavior at the repository edge.
+
+```go
+type ValidationSummary struct {
+    Status string `json:"status"`
+}
+
+type FilingRow struct {
+    ID                string                           `db:"id"`
+    ValidationSummary orm.JSONField[ValidationSummary] `db:"validation_summary"`
+}
+
+summary := row.ValidationSummary.OrDefault(ValidationSummary{Status: "unknown"})
+```
+
+For insert/update maps, `JSONOf(value)` stores typed JSON and `JSONNull[T]()`
+stores SQL NULL. `NullString`, `NullStringPtr`, and `NullStringEmpty` are small
+helpers for optional string/UUID fields represented as `sql.NullString`.
+
+Wide read projections should use explicit select aliases and dedicated row
+structs. For nested JSON aggregate snapshots, keep the raw SQL in a small
+repository method, require raw approval, and scan into a typed row containing
+`JSONField[T]` fields. That preserves the SQL review boundary without forcing
+nested aggregate SQL into the structured builder.
+
 ## Scope-Based Advanced Path
 
 `Scope` lets you keep reusable query fragments near the generic helpers instead of dropping straight to ad-hoc builder code everywhere.
@@ -650,6 +743,33 @@ tenantDocs := orm.ComposeScopes(
 scopeBindings := orm.TenantScope(tenantID, "scope_tenant_id")
 ```
 
+### `CursorAfter(...)` and `CursorBefore(...)`
+
+Cursor scopes add keyset pagination predicates without hand-written raw SQL.
+The helper expands ordered columns into a lexicographic predicate, so mixed
+ascending and descending cursor columns remain explicit.
+
+```go
+rows, err := orm.SelectAllBy[WorkQueueRow](
+    ctx,
+    db,
+    db.Table("filing_cases").
+        Select("id", "due_at", "title").
+        OrderBy("due_at", "desc").
+        OrderBy("id", "desc").
+        Limit(50),
+    orm.TenantScope(tenantID),
+    orm.CursorAfter(
+        []orm.CursorColumn{
+            orm.CursorDesc("due_at"),
+            orm.CursorDesc("id"),
+        },
+        cursorDueAt,
+        cursorID,
+    ),
+)
+```
+
 ### `SelectOneBy[T]` and `SelectAllBy[T]`
 
 These helpers build SQL from a scoped query and still scan through the generic read path.
@@ -694,7 +814,7 @@ _, err := orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"
 - Reads only support struct destinations and `map[string]any`. Pointer destinations are not supported.
 - Writes only support non-pointer struct values and `map[string]any`.
 - Generic `Update` only supports primary-key-based updates through `WherePK()`. For arbitrary predicates, use `UpdateBy` or `UpdateByReturning`.
-- Generic `Upsert` can use `WherePK()`, `ConflictColumns(...)`, or `ConflictConstraint(...)`.
+- Generic `Upsert` can use `WherePK()`, `ConflictColumns(...)`, `ConflictConstraint(...)`, or `ConflictTargetRaw(...)`.
 - Scoped helpers are the recommended bridge when you want arbitrary predicates, joins, or `DELETE` while still keeping generic read/write helpers as the main public API.
 - Struct `Update` and `Upsert` depend on `db:"...,pk"` tags. Without them, `WherePK()` has no primary-key columns to use.
 - Since generic writes take struct values, a `TableName() string` override must be available on the value type. A pointer-receiver-only `TableName` method is not picked up here.

--- a/docs/orm/query/README.md
+++ b/docs/orm/query/README.md
@@ -757,7 +757,7 @@ SafeWhereRaw appends a raw WHERE condition ensuring a values map is always used.
 func (q *Query) Select(cols ...string) *Query
 ```
 
-Select sets selected columns.
+Select sets selected identifier columns. Use SelectRaw for SQL expressions.
 
 <a name="Query.SelectRaw"></a>
 ### func \(\*Query\) [SelectRaw](<https://github.com/faciam-dev/goquent/blob/main/orm/query/query.go#L257>)

--- a/orm/json.go
+++ b/orm/json.go
@@ -1,0 +1,87 @@
+package orm
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// JSONField maps a JSON/JSONB column to a typed Go value.
+//
+// A NULL database value scans to Valid=false and leaves Data as the zero value.
+// Use OrDefault when repository code wants a stable default for nullable JSON.
+type JSONField[T any] struct {
+	Data  T
+	Valid bool
+}
+
+// JSONOf returns a valid JSONField for v.
+func JSONOf[T any](v T) JSONField[T] {
+	return JSONField[T]{Data: v, Valid: true}
+}
+
+// JSONNull returns an invalid JSONField that stores as SQL NULL.
+func JSONNull[T any]() JSONField[T] {
+	return JSONField[T]{}
+}
+
+// Scan implements sql.Scanner.
+func (j *JSONField[T]) Scan(src any) error {
+	if j == nil {
+		return fmt.Errorf("goquent: JSONField scan target is nil")
+	}
+	if src == nil {
+		var zero T
+		j.Data = zero
+		j.Valid = false
+		return nil
+	}
+	var raw []byte
+	switch v := src.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		return fmt.Errorf("goquent: cannot scan JSONField from %T", src)
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return fmt.Errorf("goquent: JSONField cannot scan empty JSON")
+	}
+	var data T
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return err
+	}
+	j.Data = data
+	j.Valid = true
+	return nil
+}
+
+// Value implements driver.Valuer.
+func (j JSONField[T]) Value() (driver.Value, error) {
+	if !j.Valid {
+		return nil, nil
+	}
+	b, err := json.Marshal(j.Data)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// OrDefault returns Data when valid, otherwise def.
+func (j JSONField[T]) OrDefault(def T) T {
+	if !j.Valid {
+		return def
+	}
+	return j.Data
+}
+
+// Validate runs fn for valid JSON values.
+func (j JSONField[T]) Validate(fn func(T) error) error {
+	if !j.Valid || fn == nil {
+		return nil
+	}
+	return fn(j.Data)
+}

--- a/orm/json_test.go
+++ b/orm/json_test.go
@@ -1,0 +1,69 @@
+package orm
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type jsonSummary struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+func TestJSONFieldScanValueDefaultAndValidate(t *testing.T) {
+	var field JSONField[jsonSummary]
+	if err := field.Scan([]byte(`{"status":"ok","count":2}`)); err != nil {
+		t.Fatalf("scan json: %v", err)
+	}
+	if !field.Valid || field.Data.Status != "ok" || field.Data.Count != 2 {
+		t.Fatalf("unexpected field: %+v", field)
+	}
+	value, err := field.Value()
+	if err != nil {
+		t.Fatalf("value: %v", err)
+	}
+	if !strings.Contains(value.(string), `"status":"ok"`) {
+		t.Fatalf("unexpected JSON value: %v", value)
+	}
+	if got := (JSONField[jsonSummary]{}).OrDefault(jsonSummary{Status: "empty"}); got.Status != "empty" {
+		t.Fatalf("default=%+v", got)
+	}
+	if err := field.Validate(func(v jsonSummary) error {
+		if v.Count != 2 {
+			return errors.New("bad count")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestJSONFieldNullAndNullableStrings(t *testing.T) {
+	field := JSONOf(jsonSummary{Status: "ok"})
+	if err := field.Scan(nil); err != nil {
+		t.Fatalf("scan null: %v", err)
+	}
+	if field.Valid {
+		t.Fatalf("expected invalid null field: %+v", field)
+	}
+	value, err := field.Value()
+	if err != nil {
+		t.Fatalf("value null: %v", err)
+	}
+	if value != nil {
+		t.Fatalf("expected nil driver value, got %v", value)
+	}
+
+	tenant := "tenant-1"
+	if got := NullStringPtr(&tenant); !got.Valid || got.String != "tenant-1" {
+		t.Fatalf("NullStringPtr=%+v", got)
+	}
+	if got := NullStringPtr(nil); got.Valid {
+		t.Fatalf("nil NullStringPtr=%+v", got)
+	}
+	if got := NullStringEmpty(""); got != (sql.NullString{}) {
+		t.Fatalf("empty NullString=%+v", got)
+	}
+}

--- a/orm/nullable.go
+++ b/orm/nullable.go
@@ -1,0 +1,24 @@
+package orm
+
+import "database/sql"
+
+// NullString returns a valid sql.NullString.
+func NullString(value string) sql.NullString {
+	return sql.NullString{String: value, Valid: true}
+}
+
+// NullStringPtr returns NULL when value is nil and a valid sql.NullString otherwise.
+func NullStringPtr(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return NullString(*value)
+}
+
+// NullStringEmpty returns NULL when value is empty and a valid sql.NullString otherwise.
+func NullStringEmpty(value string) sql.NullString {
+	if value == "" {
+		return sql.NullString{}
+	}
+	return NullString(value)
+}

--- a/orm/query/plan_test.go
+++ b/orm/query/plan_test.go
@@ -87,6 +87,86 @@ func TestSelectPlanSnapshot(t *testing.T) {
 	}
 }
 
+func TestSelectRejectsExpressionLikeFields(t *testing.T) {
+	cases := []string{
+		"CASE WHEN result IS NULL THEN NULL ELSE result::text END AS result_json",
+		"COUNT(id)",
+		"result::text",
+		"name AS display_name",
+		"result->>'status'",
+		"first name",
+	}
+
+	for _, field := range cases {
+		t.Run(field, func(t *testing.T) {
+			_, err := newPlanTestQuery(&recordingExec{}).
+				Select("finished_at", field).
+				Plan(context.Background())
+			if err == nil {
+				t.Fatal("expected Select expression-like field error")
+			}
+			if !strings.Contains(err.Error(), "SelectRaw(...)") || !strings.Contains(err.Error(), field) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSelectRawAcceptsExpressionSelection(t *testing.T) {
+	exec := &recordingExec{}
+	plan, err := newPlanTestQuery(exec).
+		Select("finished_at").
+		SelectRaw("CASE WHEN result IS NULL THEN NULL ELSE result::text END AS result_json").
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if exec.calls != 0 {
+		t.Fatalf("Plan executed database call count=%d", exec.calls)
+	}
+	if !strings.Contains(plan.SQL, "CASE WHEN result IS NULL THEN NULL ELSE result::text END AS result_json") {
+		t.Fatalf("sql=%q", plan.SQL)
+	}
+}
+
+func TestSelectAllowsIdentifierAndWildcardFields(t *testing.T) {
+	_, err := newPlanTestQuery(&recordingExec{}).
+		Select("id", "users.name", "*", "profiles.*").
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+}
+
+func TestWhereCursorAfterBuildsLexicographicPredicate(t *testing.T) {
+	plan, err := New(&recordingExec{}, "jobs", ormdriver.PostgresDialect{}).
+		Select("id").
+		WhereCursorAfter([]CursorColumn{CursorDesc("due_at"), CursorDesc("id")}, "2026-05-19T00:00:00Z", "job-1").
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(plan.SQL, `"due_at" <`) || !strings.Contains(plan.SQL, `"due_at" =`) || !strings.Contains(plan.SQL, `"id" <`) {
+		t.Fatalf("expected descending cursor predicate, sql=%q", plan.SQL)
+	}
+	if len(plan.Params) != 3 ||
+		plan.Params[0] != "2026-05-19T00:00:00Z" ||
+		plan.Params[1] != "2026-05-19T00:00:00Z" ||
+		plan.Params[2] != "job-1" {
+		t.Fatalf("params=%#v", plan.Params)
+	}
+}
+
+func TestWhereCursorRejectsInvalidInput(t *testing.T) {
+	_, err := newPlanTestQuery(&recordingExec{}).
+		Select("id").
+		WhereCursorAfter([]CursorColumn{CursorAsc("due_at")}, "cursor", 1).
+		Plan(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "cursor column/value count mismatch") {
+		t.Fatalf("expected count mismatch error, got %v", err)
+	}
+}
+
 func TestWritePlanSnapshots(t *testing.T) {
 	ctx := context.Background()
 

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -51,6 +51,22 @@ type Query struct {
 	policyApplied bool
 }
 
+// CursorColumn describes an ordered column used by keyset cursor predicates.
+type CursorColumn struct {
+	Name      string
+	Direction string
+}
+
+// CursorAsc returns an ascending keyset cursor column.
+func CursorAsc(name string) CursorColumn {
+	return CursorColumn{Name: name, Direction: "asc"}
+}
+
+// CursorDesc returns a descending keyset cursor column.
+func CursorDesc(name string) CursorColumn {
+	return CursorColumn{Name: name, Direction: "desc"}
+}
+
 // New creates a Query with given db and table.
 func New(exec executor, table string, dialect driver.Dialect) *Query {
 	builder := newSelectBuilder(dialect)
@@ -238,8 +254,17 @@ func (q *Query) execStmt(sqlStr string, args ...any) (sql.Result, error) {
 	return q.exec.Exec(sqlStr, args...)
 }
 
-// Select sets selected columns.
+// Select sets selected identifier columns. Use SelectRaw for SQL expressions.
 func (q *Query) Select(cols ...string) *Query {
+	if q.err != nil {
+		return q
+	}
+	for _, col := range cols {
+		if err := validateSelectColumn(col); err != nil {
+			q.err = err
+			return q
+		}
+	}
 	q.builder.Select(cols...)
 	return q
 }
@@ -270,6 +295,48 @@ func (q *Query) Where(col string, args ...any) *Query {
 		q.err = fmt.Errorf("invalid Where usage")
 	}
 	return q
+}
+
+// WhereCursorAfter adds a keyset pagination predicate after the given cursor.
+func (q *Query) WhereCursorAfter(columns []CursorColumn, values ...any) *Query {
+	return q.whereCursor(columns, values, true)
+}
+
+// WhereCursorBefore adds a keyset pagination predicate before the given cursor.
+func (q *Query) WhereCursorBefore(columns []CursorColumn, values ...any) *Query {
+	return q.whereCursor(columns, values, false)
+}
+
+func (q *Query) whereCursor(columns []CursorColumn, values []any, after bool) *Query {
+	if q.err != nil {
+		return q
+	}
+	normalized, err := validateCursorColumns(columns, values)
+	if err != nil {
+		q.err = err
+		return q
+	}
+	raw, vals := q.cursorPredicate(normalized, values, after)
+	q.builder.WhereRaw(raw, vals)
+	return q
+}
+
+func (q *Query) cursorPredicate(columns []CursorColumn, values []any, after bool) (string, map[string]any) {
+	vals := make(map[string]any)
+	parts := make([]string, 0, len(columns))
+	for i := range columns {
+		comparisons := make([]string, 0, i+1)
+		for j := 0; j < i; j++ {
+			name := fmt.Sprintf("__goquent_cursor_%d_%d", i, j)
+			vals[name] = values[j]
+			comparisons = append(comparisons, fmt.Sprintf("%s = :%s", quoteIdentifierPath(q.dialect, columns[j].Name), name))
+		}
+		name := fmt.Sprintf("__goquent_cursor_%d_%d", i, i)
+		vals[name] = values[i]
+		comparisons = append(comparisons, fmt.Sprintf("%s %s :%s", quoteIdentifierPath(q.dialect, columns[i].Name), cursorComparisonOperator(columns[i].Direction, after), name))
+		parts = append(parts, "("+strings.Join(comparisons, " AND ")+")")
+	}
+	return "(" + strings.Join(parts, " OR ") + ")", vals
 }
 
 // First scans the first result into dest struct.
@@ -1819,6 +1886,105 @@ func validateRawSQLFragment(raw string) error {
 		}
 	}
 	return nil
+}
+
+func validateSelectColumn(col string) error {
+	trimmed := strings.TrimSpace(col)
+	if trimmed == "" {
+		return fmt.Errorf("goquent: Select column name is required")
+	}
+	if trimmed != col || selectFieldLooksLikeSQLExpression(trimmed) {
+		return fmt.Errorf("goquent: Select received a SQL expression-like field %q; use SelectRaw(...) for SQL expressions", col)
+	}
+	return nil
+}
+
+func validateCursorColumns(columns []CursorColumn, values []any) ([]CursorColumn, error) {
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("goquent: cursor columns are required")
+	}
+	if len(columns) != len(values) {
+		return nil, fmt.Errorf("goquent: cursor column/value count mismatch")
+	}
+	normalized := make([]CursorColumn, len(columns))
+	for i, col := range columns {
+		name := strings.TrimSpace(col.Name)
+		if name == "" {
+			return nil, fmt.Errorf("goquent: cursor column name is required")
+		}
+		if strings.Contains(name, "*") {
+			return nil, fmt.Errorf("goquent: cursor column %q cannot be a wildcard", col.Name)
+		}
+		if err := validateSelectColumn(name); err != nil {
+			return nil, fmt.Errorf("goquent: invalid cursor column %q: %w", col.Name, err)
+		}
+		dir, err := validateOrderDirection(col.Direction)
+		if err != nil {
+			return nil, err
+		}
+		if values[i] == nil {
+			return nil, fmt.Errorf("goquent: cursor value for %s is nil", name)
+		}
+		normalized[i] = CursorColumn{Name: name, Direction: dir}
+	}
+	return normalized, nil
+}
+
+func cursorComparisonOperator(direction string, after bool) string {
+	desc := strings.EqualFold(direction, "desc")
+	if after {
+		if desc {
+			return "<"
+		}
+		return ">"
+	}
+	if desc {
+		return ">"
+	}
+	return "<"
+}
+
+func quoteIdentifierPath(d driver.Dialect, ident string) string {
+	parts := strings.Split(ident, ".")
+	for i, part := range parts {
+		parts[i] = d.QuoteIdent(part)
+	}
+	return strings.Join(parts, ".")
+}
+
+func selectFieldLooksLikeSQLExpression(field string) bool {
+	if strings.ContainsAny(field, " \t\r\n\v\f()[],;'\"`\x00") ||
+		strings.Contains(field, "::") ||
+		strings.Contains(field, "--") ||
+		strings.Contains(field, "/*") ||
+		strings.Contains(field, "*/") {
+		return true
+	}
+	if selectFieldHasInvalidWildcard(field) {
+		return true
+	}
+	for _, op := range []string{"->", "->>", "+", "-", "/", "%", "=", "<", ">", "||", "&"} {
+		if strings.Contains(field, op) {
+			return true
+		}
+	}
+	upper := strings.ToUpper(field)
+	for _, token := range []string{"AS", "CASE"} {
+		if containsSQLWord(upper, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func selectFieldHasInvalidWildcard(field string) bool {
+	if !strings.Contains(field, "*") {
+		return false
+	}
+	if field == "*" {
+		return false
+	}
+	return !(strings.HasSuffix(field, ".*") && strings.Count(field, "*") == 1)
 }
 
 func validateColumnComparisons(columns [][]string) error {

--- a/orm/scope.go
+++ b/orm/scope.go
@@ -12,6 +12,15 @@ import (
 // Scope applies reusable query mutations for advanced read and write flows.
 type Scope func(*query.Query) *query.Query
 
+// CursorColumn describes an ordered column used by keyset cursor scopes.
+type CursorColumn = query.CursorColumn
+
+// CursorAsc returns an ascending keyset cursor column.
+func CursorAsc(name string) CursorColumn { return query.CursorAsc(name) }
+
+// CursorDesc returns a descending keyset cursor column.
+func CursorDesc(name string) CursorColumn { return query.CursorDesc(name) }
+
 // ApplyScopes applies scopes to q in order. Nil scopes are ignored.
 // If a scope returns nil, the current query is kept.
 func ApplyScopes(q *query.Query, scopes ...Scope) *query.Query {
@@ -43,6 +52,20 @@ func TenantScope(tenantID any, column ...string) Scope {
 	}
 	return func(q *query.Query) *query.Query {
 		return q.Where(col, tenantID)
+	}
+}
+
+// CursorAfter adds a keyset pagination predicate after the given cursor.
+func CursorAfter(columns []CursorColumn, values ...any) Scope {
+	return func(q *query.Query) *query.Query {
+		return q.WhereCursorAfter(columns, values...)
+	}
+}
+
+// CursorBefore adds a keyset pagination predicate before the given cursor.
+func CursorBefore(columns []CursorColumn, values ...any) Scope {
+	return func(q *query.Query) *query.Query {
+		return q.WhereCursorBefore(columns, values...)
 	}
 }
 

--- a/orm/write.go
+++ b/orm/write.go
@@ -3,12 +3,15 @@ package orm
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/faciam-dev/goquent/orm/driver"
 	"github.com/faciam-dev/goquent/orm/model"
+	"github.com/faciam-dev/goquent/orm/query"
 )
 
 // WriteOpt configures write behavior.
@@ -24,6 +27,7 @@ type writeOptions struct {
 	conflictCols       []string
 	conflictWhere      string
 	conflictConstraint string
+	conflictTargetRaw  string
 	upsertUpdateCols   []string
 	hasUpsertUpdates   bool
 }
@@ -71,6 +75,18 @@ func ConflictWhere(predicate string) WriteOpt {
 // ConflictConstraint sets a Postgres named constraint as the conflict target.
 func ConflictConstraint(name string) WriteOpt {
 	return func(o *writeOptions) { o.conflictConstraint = name }
+}
+
+// ConflictTargetRaw sets a raw Postgres ON CONFLICT target.
+//
+// Use this for expression indexes such as:
+//
+//	ConflictTargetRaw(`("tenant_id", COALESCE("target_node_id", '')) WHERE "active"`)
+//
+// Prefer ConflictColumns, ConflictWhere, or ConflictConstraint when they can
+// express the target.
+func ConflictTargetRaw(target string) WriteOpt {
+	return func(o *writeOptions) { o.conflictTargetRaw = target }
 }
 
 // UpdateColumns limits the conflict UPDATE side of Upsert/UpsertReturning.
@@ -122,7 +138,9 @@ func (o *writeOptions) isPK(col string) bool {
 }
 
 func (o *writeOptions) hasConflictTarget() bool {
-	return len(o.conflictCols) > 0 || strings.TrimSpace(o.conflictConstraint) != ""
+	return len(o.conflictCols) > 0 ||
+		strings.TrimSpace(o.conflictConstraint) != "" ||
+		strings.TrimSpace(o.conflictTargetRaw) != ""
 }
 
 func (o *writeOptions) isConflictColumn(col string) bool {
@@ -529,6 +547,40 @@ func UpsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...Wri
 	return queryReturningOne[T](ctx, db, sqlStr, args...)
 }
 
+// InsertOnceReturning inserts v once and scans the inserted or existing row.
+//
+// It uses ON CONFLICT DO NOTHING RETURNING for the insert attempt. If the
+// conflict path returns no row, it looks up the existing row by ConflictColumns
+// or WherePK primary-key columns. Expression-only raw conflict targets need
+// ConflictColumns or WherePK as a lookup key.
+func InsertOnceReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...WriteOpt) (T, bool, error) {
+	var zero T
+	o := applyWriteOpts(opts)
+	if err := ensureReturningColumns[T](o); err != nil {
+		return zero, false, err
+	}
+	o.upsertUpdateCols = nil
+	o.hasUpsertUpdates = true
+
+	sqlStr, args, err := buildUpsertStatement(db, v, o)
+	if err != nil {
+		return zero, false, err
+	}
+	inserted, err := queryReturningOne[T](ctx, db, sqlStr, args...)
+	if err == nil {
+		return inserted, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return zero, false, err
+	}
+
+	existing, err := selectExistingInsertOnceRow[T](ctx, db, v, o)
+	if err != nil {
+		return zero, false, err
+	}
+	return existing, false, nil
+}
+
 func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	if !o.wherePK && !o.hasConflictTarget() {
 		return "", nil, fmt.Errorf("Upsert[T] requires WherePK, ConflictColumns, or ConflictConstraint")
@@ -647,8 +699,8 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	}
 	switch db.drv.Dialect.(type) {
 	case driver.MySQLDialect:
-		if strings.TrimSpace(o.conflictWhere) != "" || strings.TrimSpace(o.conflictConstraint) != "" {
-			return "", nil, fmt.Errorf("ConflictWhere and ConflictConstraint are not supported on dialect: %T", db.drv.Dialect)
+		if strings.TrimSpace(o.conflictWhere) != "" || strings.TrimSpace(o.conflictConstraint) != "" || strings.TrimSpace(o.conflictTargetRaw) != "" {
+			return "", nil, fmt.Errorf("ConflictWhere, ConflictConstraint, and ConflictTargetRaw are not supported on dialect: %T", db.drv.Dialect)
 		}
 		if len(updateCols) > 0 {
 			assigns := make([]string, len(updateCols))
@@ -681,6 +733,85 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 		return "", nil, err
 	}
 	return sqlStr, args, nil
+}
+
+func selectExistingInsertOnceRow[T any](ctx context.Context, db *DB, v any, o *writeOptions) (T, error) {
+	var zero T
+	table, values, pkCols, err := writeLookupValues(v, o)
+	if err != nil {
+		return zero, err
+	}
+	lookupCols := dedupeColumns(o.conflictCols)
+	if len(lookupCols) == 0 {
+		lookupCols = pkCols
+	}
+	if len(lookupCols) == 0 {
+		return zero, fmt.Errorf("InsertOnceReturning existing-row lookup requires ConflictColumns or WherePK primary key columns")
+	}
+
+	q := db.Table(table).Select(o.returning...)
+	for _, col := range lookupCols {
+		value, ok := values[col]
+		if !ok {
+			return zero, fmt.Errorf("InsertOnceReturning lookup requires column %s", col)
+		}
+		q.Where(col, value)
+	}
+	if predicate := strings.TrimSpace(o.conflictWhere); predicate != "" {
+		q.WhereRawNoArgs(predicate)
+	}
+	plan, err := q.Plan(ctx)
+	if err != nil {
+		return zero, err
+	}
+	if err := query.EnsurePlanExecutable(plan); err != nil {
+		return zero, err
+	}
+	return SelectOne[T](ctx, db.RequireRawApproval("goquent generated insert-once lookup"), plan.SQL, plan.Params...)
+}
+
+func writeLookupValues(v any, o *writeOptions) (string, map[string]any, []string, error) {
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+	values := make(map[string]any)
+	var table string
+	var pkCols []string
+
+	if isMapStringInterface(typ) {
+		if o.table == "" {
+			return "", nil, nil, fmt.Errorf("Table option required for map writes")
+		}
+		table = o.table
+		iter := val.MapRange()
+		for iter.Next() {
+			values[iter.Key().String()] = iter.Value().Interface()
+		}
+		if o.wherePK {
+			for col := range o.pkCols {
+				pkCols = append(pkCols, col)
+			}
+			sort.Strings(pkCols)
+		}
+		return table, values, pkCols, nil
+	}
+
+	if typ.Kind() != reflect.Struct {
+		return "", nil, nil, fmt.Errorf("unsupported type %s", typ)
+	}
+	table = o.table
+	if table == "" {
+		table = model.TableName(v)
+	}
+	meta, err := getTypeMeta(typ)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	for _, fm := range meta.FieldsByName {
+		fv := val.FieldByIndex(fm.IndexPath)
+		values[fm.Col] = fv.Interface()
+	}
+	pkCols = append(pkCols, meta.PKCols...)
+	return table, values, pkCols, nil
 }
 
 func conflictTargetColumns(o *writeOptions, pkCols []string) []string {
@@ -762,8 +893,24 @@ func ensureUpsertUpdateColumnsPresent(updateCols []string, insertCols []string) 
 }
 
 func postgresConflictTarget(d driver.Dialect, cols []string, o *writeOptions) (string, error) {
+	rawTarget := strings.TrimSpace(o.conflictTargetRaw)
 	constraint := strings.TrimSpace(o.conflictConstraint)
 	predicate := strings.TrimSpace(o.conflictWhere)
+	if rawTarget != "" {
+		if len(o.conflictCols) > 0 {
+			return "", fmt.Errorf("ConflictTargetRaw cannot be combined with ConflictColumns")
+		}
+		if constraint != "" {
+			return "", fmt.Errorf("ConflictTargetRaw cannot be combined with ConflictConstraint")
+		}
+		if predicate != "" {
+			return "", fmt.Errorf("ConflictTargetRaw cannot be combined with ConflictWhere")
+		}
+		if err := validateWriteRawSQLFragment(rawTarget); err != nil {
+			return "", err
+		}
+		return rawTarget, nil
+	}
 	if constraint != "" {
 		if len(o.conflictCols) > 0 {
 			return "", fmt.Errorf("ConflictConstraint cannot be combined with ConflictColumns")

--- a/orm/write_test.go
+++ b/orm/write_test.go
@@ -422,6 +422,82 @@ func TestUpsertConflictDoNothing(t *testing.T) {
 	}
 }
 
+func TestUpsertPostgresConflictTargetRaw(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{
+			"tenant_id":      "tenant-1",
+			"target_node_id": nil,
+			"payload_json":   "{}",
+		},
+		Table("citation_links"),
+		ConflictTargetRaw(`("tenant_id", COALESCE("target_node_id", '')) WHERE "active"`),
+		ConflictDoNothing(),
+	)
+	if err != nil {
+		t.Fatalf("upsert raw conflict target: %v", err)
+	}
+	if !strings.Contains(exec.query, `ON CONFLICT ("tenant_id", COALESCE("target_node_id", '')) WHERE "active" DO NOTHING`) {
+		t.Fatalf("expected raw expression conflict target, got: %s", exec.query)
+	}
+}
+
+func TestInsertOnceReturningInsertedRow(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`INSERT INTO "users".*ON CONFLICT \("id"\) DO NOTHING RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(5, "alice", 32))
+
+	row, inserted, err := InsertOnceReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 5, Name: "alice", Age: 32},
+		WherePK(),
+	)
+	if err != nil {
+		t.Fatalf("insert once returning: %v", err)
+	}
+	if !inserted {
+		t.Fatal("expected inserted=true")
+	}
+	if row.ID != 5 || row.Name != "alice" || row.Age != 32 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestInsertOnceReturningExistingRow(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`INSERT INTO "users".*ON CONFLICT \("id"\) DO NOTHING RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}))
+	mock.ExpectQuery(`SELECT "id", "name", "age" FROM "users" WHERE "id" = \$1`).
+		WithArgs(int64(5)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).AddRow(5, "existing", 40))
+
+	row, inserted, err := InsertOnceReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 5, Name: "alice", Age: 32},
+		WherePK(),
+	)
+	if err != nil {
+		t.Fatalf("insert once returning existing: %v", err)
+	}
+	if inserted {
+		t.Fatal("expected inserted=false")
+	}
+	if row.ID != 5 || row.Name != "existing" || row.Age != 40 {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestUpsertUpdateColumnsRequireInsertedColumn(t *testing.T) {
 	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
 


### PR DESCRIPTION
## Summary

- Treat `Select(...)` as an identifier-only API and reject SQL expression-like fields with guidance to use `SelectRaw(...)`.
- Add PostgreSQL conflict target support for expression indexes via `ConflictTargetRaw(...)`.
- Add `InsertOnceReturning(...)` for idempotent append-only writes that return either the inserted row or the existing row.
- Add keyset cursor helpers for structured pagination predicates.
- Add typed JSON and nullable string helpers for repository rows and insert maps.
- Document upsert, cursor pagination, JSON/projection, and raw aggregate patterns.

## Tests

- `go test ./orm ./orm/query`
- `go test ./orm -run 'Test(UpsertPostgresConflictTargetRaw|InsertOnceReturning|JSONField|JSONFieldNull)'`
- `go test ./orm/query -run 'Test(WhereCursor|SelectRejects|SelectRawAccepts|SelectAllows)'`
- `go test ./... -run ^$`
- `go test ./cmd/goquent ./orm/...`