### PR TITLE
Strengthen AI-safe review gates and manifest-aware static analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## Unreleased
+- Hardened `goquent review --require-fresh-manifest`: missing, stale, or unverified manifests now
+  fail the manifest gate, and review can verify current `--schema`, `--policy`, `--code`, and
+  `--database-schema` inputs directly.
+- Added JSON review config support for manifest defaults, `fail_on_precision`, rule severity
+  overrides, and config-scoped suppressions with reason/owner/expiration metadata.
+- Made static Go review manifest-aware for literal table query chains, including tenant scope,
+  soft delete, PII, required-filter, and manifest key metadata checks.
+- Tightened bulk write risk detection so foreign-key-looking columns such as `tenant_id` are not
+  treated as primary-key-like by name alone; manifest primary keys and unique indexes can provide
+  narrow-write metadata.
+- `OperationSpec` now rejects unresolved `value_ref` entries instead of compiling placeholder
+  strings into query params.
 - `Where` no longer attempts to automatically detect dotted values as column names.
   Use `WhereColumn` for column-to-column comparisons.
 - Added generic `SelectOne` and `SelectAll` APIs supporting struct and map destinations.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ go run ./cmd/goquent review \
   --format github \
   --fail-on high \
   --manifest goquent.manifest.json \
+  --schema schema.json \
+  --policy policies.json \
   --require-fresh-manifest \
   ./...
 ```
@@ -161,7 +163,9 @@ go run ./cmd/goquent manifest verify \
   --policy policies.json
 ```
 
-Use `review --require-fresh-manifest` when stale schema or policy context should fail CI. A stale manifest is not a warning to ignore; regenerate it or stop using it as authoritative context.
+Use `review --require-fresh-manifest` with current inputs such as `--schema`, `--policy`, `--code`,
+or `--database-schema` when stale or unverified schema or policy context should fail CI. A stale
+manifest is not a warning to ignore; regenerate it or stop using it as authoritative context.
 
 ## MCP Server
 

--- a/cmd/goquent/main.go
+++ b/cmd/goquent/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/faciam-dev/goquent/orm/manifest"
 	"github.com/faciam-dev/goquent/orm/review"
 )
 
@@ -47,11 +48,17 @@ func runReview(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("goquent review", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	failOn := fs.String("fail-on", "high", "risk threshold that returns exit code 1")
+	failOnPrecision := fs.String("fail-on-precision", "", "analysis precision threshold that returns exit code 1: partial or unsupported")
 	format := fs.String("format", "pretty", "output format: pretty, json, github")
 	showSuppressed := fs.Bool("show-suppressed", false, "include suppressed findings in the primary output")
-	configPath := fs.String("config", "", "reserved path to a goquent review config file")
+	configPath := fs.String("config", "", "path to a JSON goquent review config file")
 	manifestPath := fs.String("manifest", "", "manifest JSON path for freshness warnings")
+	schemaPath := fs.String("schema", "", "current schema JSON path for manifest freshness verification")
+	policyPath := fs.String("policy", "", "current table policy JSON path for manifest freshness verification")
+	databaseSchemaPath := fs.String("database-schema", "", "current database schema JSON path for manifest freshness verification")
 	requireFreshManifest := fs.Bool("require-fresh-manifest", false, "return exit code 3 when the manifest is stale")
+	var codePaths stringListFlag
+	fs.Var(&codePaths, "code", "current generated code file or directory path for manifest freshness verification; may be repeated")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: goquent review [flags] [path ...]")
 		fs.PrintDefaults()
@@ -59,13 +66,69 @@ func runReview(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	_ = strings.TrimSpace(*configPath)
+	explicit := explicitFlagSet(fs)
+	var cfg review.Config
+	if strings.TrimSpace(*configPath) != "" {
+		loaded, err := review.LoadConfig(*configPath)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		cfg = loaded
+		if !explicit["manifest"] && cfg.Manifest != "" {
+			*manifestPath = cfg.Manifest
+		}
+		if !explicit["schema"] && cfg.Schema != "" {
+			*schemaPath = cfg.Schema
+		}
+		if !explicit["policy"] && cfg.Policy != "" {
+			*policyPath = cfg.Policy
+		}
+		if !explicit["database-schema"] && cfg.DatabaseSchema != "" {
+			*databaseSchemaPath = cfg.DatabaseSchema
+		}
+		if !explicit["code"] && len(cfg.Code) > 0 {
+			codePaths = append(stringListFlag(nil), cfg.Code...)
+		}
+		if !explicit["require-fresh-manifest"] && cfg.RequireFreshManifest {
+			*requireFreshManifest = true
+		}
+		if !explicit["fail-on"] && cfg.FailOn != "" {
+			*failOn = cfg.FailOn
+		}
+		if !explicit["fail-on-precision"] && cfg.FailOnPrecision != "" {
+			*failOnPrecision = cfg.FailOnPrecision
+		}
+		if !explicit["show-suppressed"] && cfg.ShowSuppressed {
+			*showSuppressed = true
+		}
+	}
+
+	manifestInputs := strings.TrimSpace(*schemaPath) != "" ||
+		strings.TrimSpace(*policyPath) != "" ||
+		strings.TrimSpace(*databaseSchemaPath) != "" ||
+		len(codePaths) > 0
+	var currentManifestForReview *manifest.Manifest
+	if manifestInputs {
+		current, err := buildManifestFromFlags("", *schemaPath, *policyPath, *databaseSchemaPath, "", codePaths)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		currentManifestForReview = current
+	}
 
 	threshold, err := review.ParseRiskLevel(*failOn)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
+	precisionThreshold, err := review.ParseAnalysisPrecision(*failOnPrecision)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	precisionThresholdSet := strings.TrimSpace(*failOnPrecision) != ""
 	outputFormat := strings.ToLower(strings.TrimSpace(*format))
 	switch outputFormat {
 	case "", "pretty", "text", "json", "github":
@@ -79,6 +142,10 @@ func runReview(args []string, stdout, stderr io.Writer) int {
 		ShowSuppressed:       *showSuppressed,
 		ManifestPath:         *manifestPath,
 		RequireFreshManifest: *requireFreshManifest,
+		CurrentManifest:      currentManifestForReview,
+		ManifestInputs:       manifestInputs,
+		Rules:                cfg.Rules,
+		ConfigSuppressions:   cfg.Suppressions,
 	})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -104,7 +171,18 @@ func runReview(args []string, stdout, stderr io.Writer) int {
 	if review.HasFindingsAtOrAbove(report, threshold) {
 		return 1
 	}
+	if precisionThresholdSet && review.HasFindingsAtOrAbovePrecision(report, precisionThreshold) {
+		return 1
+	}
 	return 0
+}
+
+func explicitFlagSet(fs *flag.FlagSet) map[string]bool {
+	out := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		out[f.Name] = true
+	})
+	return out
 }
 
 func printUsage(w io.Writer) {

--- a/cmd/goquent/main_test.go
+++ b/cmd/goquent/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,5 +37,69 @@ func TestReviewCommandRejectsBadFormat(t *testing.T) {
 	code := run([]string{"review", "--format", "sarif"}, &stdout, &stderr)
 	if code != 2 {
 		t.Fatalf("expected config error exit code, got %d", code)
+	}
+}
+
+func TestReviewCommandConfigSuppressionAndPrecisionGate(t *testing.T) {
+	dir := t.TempDir()
+	sqlPath := filepath.Join(dir, "query.sql")
+	if err := os.WriteFile(sqlPath, []byte("SELECT * FROM users"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := map[string]any{
+		"fail_on": "high",
+		"suppressions": []map[string]any{{
+			"code":    "RAW_SQL_USED",
+			"path":    sqlPath,
+			"reason":  "reviewed SQL fixture",
+			"expires": "2026-08-01",
+		}},
+	}
+	cfgBytes, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "goquent.review.json")
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"review", "--config", cfgPath, sqlPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected config suppression to avoid high failure, got %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+
+	goPath := filepath.Join(dir, "dynamic.go")
+	if err := os.WriteFile(goPath, []byte(`package sample
+
+func run(q any) {
+	q.Update(map[string]any{"name": "x"})
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg = map[string]any{"fail_on_precision": "partial", "fail_on": "blocked"}
+	cfgBytes, err = json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{"review", "--config", cfgPath, goPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected precision gate failure, got %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+}
+
+func TestReviewCommandRequireFreshManifestWithoutManifestFails(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"review", "--require-fresh-manifest", dir}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("expected manifest freshness exit code 3, got %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 }

--- a/docs/ai-agent-playbook.md
+++ b/docs/ai-agent-playbook.md
@@ -56,6 +56,8 @@ Review the database surface:
 go run ./cmd/goquent review \
   --fail-on high \
   --manifest goquent.manifest.json \
+  --schema schema.json \
+  --policy policies.json \
   --require-fresh-manifest \
   ./...
 ```

--- a/docs/manifest-stale-detection.md
+++ b/docs/manifest-stale-detection.md
@@ -27,6 +27,8 @@ go run ./cmd/goquent manifest verify --format json \
 ```bash
 go run ./cmd/goquent review \
   --manifest goquent.manifest.json \
+  --schema schema.json \
+  --policy policies.json \
   --require-fresh-manifest \
   ./...
 ```
@@ -34,7 +36,8 @@ go run ./cmd/goquent review \
 Exit behavior:
 
 - `manifest verify` returns `0` when fresh and `1` when stale.
-- `review --require-fresh-manifest` returns `3` when the manifest is stale.
+- `review --require-fresh-manifest` returns `3` when the manifest is missing, stale, or cannot be
+  verified against current inputs.
 
 MCP exposes freshness through `goquent://manifest` and `goquent://manifest-status`.
 
@@ -46,8 +49,18 @@ go run ./cmd/goquent manifest verify \
   --schema schema.json \
   --policy policies.json \
   --code ./orm
-go run ./cmd/goquent review --manifest goquent.manifest.json --require-fresh-manifest ./...
+go run ./cmd/goquent review \
+  --manifest goquent.manifest.json \
+  --schema schema.json \
+  --policy policies.json \
+  --code ./orm \
+  --require-fresh-manifest \
+  ./...
 ```
+
+When `--require-fresh-manifest` is used, pass at least one current input such as `--schema`,
+`--policy`, `--code`, or `--database-schema`. Without current inputs, review reports
+`MANIFEST_UNVERIFIED` because the manifest cannot be trusted as fresh.
 
 If verification fails, regenerate the manifest or update the schema/policy inputs before asking AI
 tools to generate database code.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -50,6 +50,71 @@ if plan.RequiresApproval() {
 }
 ```
 
+## Lightweight Status Reader
+
+`ReadStatus` is a small readiness helper for reading the migration table. It
+answers whether the table exists, which versions are applied, what the latest
+applied version is, whether desired versions are pending, and whether a
+configured dirty column contains a dirty row.
+
+It is not a drift detector. It does not compare live database schema,
+manifests, generated code, migration file fingerprints, or application
+expectations. If the database has applied versions that are not present in the
+caller-provided desired list, the status includes a warning and marks the
+result as unknown instead of claiming a complete drift verdict.
+
+```go
+desired := []string{
+    "202605220001_create_users",
+    "202605220002_add_document_nodes",
+}
+
+status, err := migration.ReadStatus(
+    ctx,
+    sqlDB,
+    driver.PostgresDialect{},
+    desired,
+    migration.WithStatusTable("schema_migrations"),
+    migration.WithStatusAppliedAtColumn("applied_at"),
+    migration.WithStatusDirtyColumn("dirty"),
+)
+if err != nil {
+    return err
+}
+if !status.Exists || status.Dirty || len(status.Pending) > 0 {
+    // not ready
+}
+```
+
+Readiness endpoint sketch:
+
+```go
+func readyz(w http.ResponseWriter, r *http.Request) {
+    status, err := migration.ReadStatus(
+        r.Context(),
+        sqlDB,
+        driver.PostgresDialect{},
+        desiredMigrationVersions,
+        migration.WithStatusDirtyColumn("dirty"),
+    )
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusServiceUnavailable)
+        return
+    }
+    if !status.Exists || status.Dirty || len(status.Pending) > 0 {
+        http.Error(w, "migrations pending", http.StatusServiceUnavailable)
+        return
+    }
+    w.WriteHeader(http.StatusNoContent)
+}
+```
+
+The first implementation supports PostgreSQL and MySQL migration tables. The
+default table is `schema_migrations` and the default version column is
+`version`. Desired versions are supplied by the caller; file discovery and
+manifest/schema/generated-code comparison are explicit non-goals for this
+helper.
+
 ## Human-Controlled Apply
 
 `migrate apply` validates the same approval gates and requires `--driver` and `--dsn`, but it is a

--- a/docs/operation-spec.md
+++ b/docs/operation-spec.md
@@ -55,6 +55,7 @@ Current constraints:
 - The model must exist in the manifest.
 - Selected fields must be explicit.
 - Unknown or forbidden fields are rejected.
+- Every `value_ref` must be present in the supplied values map.
 - Required filters from manifest policy must be present.
 - PII fields require an access reason.
 - Joins, aggregates, group by, having, subqueries, raw SQL hints, CTEs, and mutation fields are not current OperationSpec features.

--- a/docs/orm/generic-crud.md
+++ b/docs/orm/generic-crud.md
@@ -567,6 +567,36 @@ _, err := orm.Upsert(
 
 Every column named in `UpdateColumns` must also be present in the insert column set, because PostgreSQL `EXCLUDED` and MySQL `VALUES(...)` read from the attempted insert row.
 
+### Expression assignments
+
+Use assignment options when the database should compute the updated value.
+They apply to `Update` and to the conflict-update side of `Upsert`; `Insert`
+rejects them.
+
+```go
+_, err := orm.Update(
+    ctx,
+    db,
+    map[string]any{"id": userID},
+    orm.TablePath("app", "users"),
+    orm.PK("id"),
+    orm.WherePK(),
+    orm.SetExpr("email_verified_at", "COALESCE(email_verified_at, ?)", verifiedAt),
+    orm.Increment("credential_version", 1),
+)
+```
+
+Available assignment helpers:
+
+- `SetRaw("column", "trusted_sql_expression")`
+- `SetExpr("column", "COALESCE(column, ?)", value)`
+- `Increment("column", 1)`
+- `SetColumn("updated_at", "password_changed_at")`
+
+`SetRaw` and `SetExpr` validate raw fragments to reject statement
+separators, comments, and write/DDL keywords. `SetExpr` rewrites `?`
+placeholders for the active dialect.
+
 ### `ConflictDoNothing()`
 
 `ConflictDoNothing` forces a no-op conflict action even when the insert payload contains non-conflict columns.
@@ -591,6 +621,27 @@ _, err := orm.Insert(
     db,
     map[string]any{"name": "sam"},
     orm.Table("users"),
+)
+```
+
+For schema-qualified tables, either pass a dotted table name or use
+`TablePath(...)`/`SchemaName(...)`; generic writes quote each identifier part:
+
+```go
+_, err := orm.Insert(
+    ctx,
+    db,
+    map[string]any{"name": "sam"},
+    orm.TablePath("app", "users"),
+)
+
+_, err = orm.Update(
+    ctx,
+    db,
+    User{ID: 1, Name: "sam"},
+    orm.SchemaName("app"),
+    orm.Columns("name"),
+    orm.WherePK(),
 )
 ```
 
@@ -663,6 +714,16 @@ if err := tx.Commit(); err != nil {
 
 The same pattern works with `db.Begin()`.
 
+When transaction ownership lives outside goquent, wrap the existing executor:
+
+```go
+txDB := orm.NewTxDB(sqlTx, driver.PostgresDialect{})
+_, err := orm.Update(ctx, txDB, row, orm.Columns("name"), orm.WherePK())
+```
+
+If you already have a configured `*orm.DB`, `db.WrapTx(sqlTx)` preserves its
+dialect, scan options, and raw-SQL approval state.
+
 ## JSON, nullable values, and projections
 
 Use `JSONField[T]` in persistence rows for JSON/JSONB columns when you want
@@ -684,12 +745,45 @@ summary := row.ValidationSummary.OrDefault(ValidationSummary{Status: "unknown"})
 For insert/update maps, `JSONOf(value)` stores typed JSON and `JSONNull[T]()`
 stores SQL NULL. `NullString`, `NullStringPtr`, and `NullStringEmpty` are small
 helpers for optional string/UUID fields represented as `sql.NullString`.
+Use `EncodeJSON` and `DecodeJSON` when a repository needs a plain text/JSON
+column value instead of a `sql.Scanner` field:
+
+```go
+payload, err := orm.EncodeJSON(ValidationSummary{Status: "ok"})
+summary, err := orm.DecodeJSON(rawPayload, ValidationSummary{Status: "unknown"})
+_, _ = payload, summary
+```
 
 Wide read projections should use explicit select aliases and dedicated row
 structs. For nested JSON aggregate snapshots, keep the raw SQL in a small
 repository method, require raw approval, and scan into a typed row containing
 `JSONField[T]` fields. That preserves the SQL review boundary without forcing
 nested aggregate SQL into the structured builder.
+
+For reviewed raw projections, carry both the approval reason and the touched
+table list on the DB copy:
+
+```go
+rows, err := orm.SelectAll[WorkItemRow](
+    ctx,
+    db.RequireRawApproval("reviewed work item union projection").
+        TouchedTables("filing_cases", "document_projects", "notices"),
+    sqlText,
+    tenantID,
+)
+```
+
+For PostgreSQL JSONB filters, the query builder has narrow predicates for
+common key lookups:
+
+```go
+err := db.Table("audit_events").
+    Select("id", "payload").
+    WhereJSONText("payload", "reason", "initial_sync").
+    WhereJSONHasKey("payload", "cache_invalidated_at").
+    WhereJSONNotHasKey("payload", "ignored_at").
+    GetMaps(&rows)
+```
 
 ## Scope-Based Advanced Path
 
@@ -743,6 +837,20 @@ tenantDocs := orm.ComposeScopes(
 scopeBindings := orm.TenantScope(tenantID, "scope_tenant_id")
 ```
 
+For joined queries with registered tenant policies on multiple tables, prefer qualified columns so
+the `QueryPlan` can prove each table is scoped:
+
+```go
+var out []map[string]any
+err := db.Table("users").
+    Select("users.id", "memberships.role").
+    Join("memberships", "users.id", "=", "memberships.user_id").
+    Where("users.tenant_id", tenantID).
+    Where("memberships.tenant_id", tenantID).
+    Limit(50).
+    GetMaps(&out)
+```
+
 ### `CursorAfter(...)` and `CursorBefore(...)`
 
 Cursor scopes add keyset pagination predicates without hand-written raw SQL.
@@ -770,6 +878,17 @@ rows, err := orm.SelectAllBy[WorkQueueRow](
 )
 ```
 
+For computed cursor keys, use the explicit expression helpers:
+
+```go
+scope := orm.CursorAfter(
+    []orm.CursorColumn{
+        orm.CursorDescExpr("(entity_type || ':' || entity_id)"),
+    },
+    cursorEntityKey,
+)
+```
+
 ### `SelectOneBy[T]` and `SelectAllBy[T]`
 
 These helpers build SQL from a scoped query and still scan through the generic read path.
@@ -793,6 +912,29 @@ _, err := orm.UpdateBy(
 )
 ```
 
+Use `UpdateByReturningWithOptions` for optimistic concurrency guards where zero
+rows should be treated as a stale-write conflict instead of a generic not-found:
+
+```go
+updated, err := orm.UpdateByReturningWithOptions[EditSessionRow](
+    ctx,
+    db,
+    db.Table("document_edit_sessions"),
+    map[string]any{"draft_nodes_json": payload},
+    []orm.WriteOpt{orm.NoRowsAs(orm.ErrConflict)},
+    func(q *query.Query) *query.Query {
+        return q.
+            Where("tenant_id", tenantID).
+            Where("id", id).
+            Where("content_hash", previousHash)
+    },
+)
+if orm.IsConflict(err) {
+    return ErrEditSessionStale
+}
+_ = updated
+```
+
 ### `DeleteBy(...)`
 
 `DeleteBy` does the same for `DELETE`.
@@ -806,6 +948,8 @@ _, err := orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"
 - goquent ships with built-in `orm.MySQL` and `orm.Postgres` driver names.
 - `SelectOne` and `SelectAll` execute the SQL string you pass in, so placeholder syntax must match your driver.
 - `Insert`, `Update`, and `Upsert` use the configured dialect to quote identifiers and build placeholders.
+- `ErrNotFound` aliases `sql.ErrNoRows`; use `IsNotFound(err)` for wrapped errors.
+- `ExpectAffected(n)` validates write row counts. Combine it with `NoRowsAs(ErrConflict)` for explicit guarded writes.
 - `Returning(...)` is PostgreSQL-only in the current implementation.
 - Bool scanning follows the same compatibility rules as the rest of goquent. See [Boolean dialect compatibility](../../README.md#boolean-dialect-compatibility).
 

--- a/docs/orm/generic-crud.md
+++ b/docs/orm/generic-crud.md
@@ -5,9 +5,11 @@ The generic API is the small set of helpers around:
 - `SelectOne[T]`
 - `SelectAll[T]`
 - `Insert[T]`
+- `InsertMany[T]`
 - `Update[T]`
 - `Upsert[T]`
 - `InsertReturning[T]`
+- `InsertManyReturning[T]`
 - `UpdateReturning[T]`
 - `UpsertReturning[T]`
 
@@ -50,6 +52,7 @@ The write side of the generic API builds simple `INSERT`, `UPDATE`, and `UPSERT`
 
 ```go
 _, err := orm.Insert(ctx, db, User{Name: "sam", Age: 18})
+_, err = orm.InsertMany(ctx, db, []User{{Name: "sam"}, {Name: "lee"}}, orm.Columns("name"))
 _, err = orm.Update(ctx, db, User{ID: 1, Name: "sam"}, orm.Columns("name"), orm.WherePK())
 _, err = orm.Upsert(ctx, db, User{ID: 1, Name: "sam", Age: 18}, orm.WherePK())
 created, err := orm.InsertReturning[User](ctx, db, User{Name: "sam", Age: 18})
@@ -197,7 +200,8 @@ type ScoreRow struct {
 
 ### Supported input shapes
 
-`Insert`, `Update`, and `Upsert` currently accept:
+`Insert`, `Update`, and `Upsert` accept one value. `InsertMany` accepts a slice
+of values. The supported element shapes are:
 
 - A non-pointer struct value
 - `map[string]any`
@@ -254,6 +258,55 @@ _, err := orm.Insert(ctx, db, map[string]any{
     "active": true,
 }, orm.Table("users"))
 ```
+
+### `InsertMany[T]`
+
+`InsertMany` builds one multi-row `INSERT` statement. It supports struct slices
+and `[]map[string]any`, uses the same `Table(...)`, `TablePath(...)`,
+`SchemaName(...)`, `Columns(...)`, `Omit(...)`, and `Returning(...)` options as
+single-row inserts, and works with transaction-wrapped `*orm.DB` values.
+
+An empty slice returns `goquent: no rows to insert`. It is not treated as a
+successful no-op.
+
+For struct slices, columns are collected in struct metadata order. All rows
+must resolve to the same column set; if `omitempty` causes one row to omit a
+column that another row includes, split the write or remove `omitempty` from
+that persistence field.
+
+```go
+_, err := orm.InsertMany(
+    ctx,
+    db,
+    []User{
+        {Name: "sam", Age: 18, Active: true},
+        {Name: "lee", Age: 22, Active: true},
+    },
+    orm.Columns("name", "age", "active"),
+)
+```
+
+For map slices, `Table(...)` is required. Without `Columns(...)`, goquent takes
+the column set from the first row after `Omit(...)` and requires every row to
+have the same keys. With `Columns(...)`, every row must provide those columns;
+extra map keys are ignored.
+
+```go
+_, err := orm.InsertMany(
+    ctx,
+    db,
+    []map[string]any{
+        {"document_id": docID, "node_id": "n1", "body": "Intro"},
+        {"document_id": docID, "node_id": "n2", "body": "Facts"},
+    },
+    orm.TablePath("app", "document_nodes"),
+    orm.Columns("document_id", "node_id", "body"),
+)
+```
+
+`InsertMany` does not support assignment or conflict/upsert options. Use
+`Upsert` for single-row conflict handling; a future bulk upsert can keep its
+own semantics instead of overloading insert.
 
 ### `Update[T]`
 
@@ -384,7 +437,10 @@ _, err := orm.Upsert(
 
 ### Typed returning helpers
 
-`InsertReturning[T]`, `UpdateReturning[T]`, and `UpsertReturning[T]` execute the same generated write statements as `Insert`, `Update`, and `Upsert`, but scan the PostgreSQL `RETURNING` row into `T`.
+`InsertReturning[T]`, `InsertManyReturning[T]`, `UpdateReturning[T]`, and
+`UpsertReturning[T]` execute the same generated write statements as `Insert`,
+`InsertMany`, `Update`, and `Upsert`, but scan PostgreSQL `RETURNING` rows into
+typed values.
 
 If you do not pass `Returning(...)`, goquent infers the returning column list from the destination struct tags.
 
@@ -393,6 +449,21 @@ created, err := orm.InsertReturning[User](
     ctx,
     db,
     User{Name: "sam", Age: 18, Active: true},
+)
+```
+
+Bulk returning scans every returned row:
+
+```go
+nodes, err := orm.InsertManyReturning[DocumentNodeRow](
+    ctx,
+    db,
+    []map[string]any{
+        {"document_id": docID, "node_id": "n1", "body": "Intro"},
+        {"document_id": docID, "node_id": "n2", "body": "Facts"},
+    },
+    orm.Table("document_nodes"),
+    orm.Returning("document_id", "node_id", "body", "created_at"),
 )
 ```
 
@@ -410,7 +481,10 @@ updated, err := orm.UpdateByReturning[User](
 )
 ```
 
-Map return values cannot infer a column list. For `InsertReturning`, `UpdateReturning`, and `UpsertReturning`, pass `Returning(...)` when the destination is `map[string]any`. `UpdateByReturning` currently infers columns from a struct destination.
+Map return values cannot infer a column list. For `InsertReturning`,
+`InsertManyReturning`, `UpdateReturning`, and `UpsertReturning`, pass
+`Returning(...)` when the destination is `map[string]any`. `UpdateByReturning`
+currently infers columns from a struct destination.
 
 ### Insert-once returning
 
@@ -497,7 +571,9 @@ _, err := orm.Update(
 )
 ```
 
-`Insert`, `Update`, and `Upsert` still return `sql.Result` when you use `Returning(...)`; they consume the returned rows to count affected rows. Use the typed returning helpers when you need row values.
+`Insert`, `InsertMany`, `Update`, and `Upsert` still return `sql.Result` when
+you use `Returning(...)`; they consume the returned rows to count affected rows.
+Use the typed returning helpers when you need row values.
 
 ### `ConflictColumns(...)`
 
@@ -571,7 +647,7 @@ Every column named in `UpdateColumns` must also be present in the insert column 
 
 Use assignment options when the database should compute the updated value.
 They apply to `Update` and to the conflict-update side of `Upsert`; `Insert`
-rejects them.
+and `InsertMany` reject them.
 
 ```go
 _, err := orm.Update(
@@ -947,7 +1023,7 @@ _, err := orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"
 
 - goquent ships with built-in `orm.MySQL` and `orm.Postgres` driver names.
 - `SelectOne` and `SelectAll` execute the SQL string you pass in, so placeholder syntax must match your driver.
-- `Insert`, `Update`, and `Upsert` use the configured dialect to quote identifiers and build placeholders.
+- `Insert`, `InsertMany`, `Update`, and `Upsert` use the configured dialect to quote identifiers and build placeholders.
 - `ErrNotFound` aliases `sql.ErrNoRows`; use `IsNotFound(err)` for wrapped errors.
 - `ExpectAffected(n)` validates write row counts. Combine it with `NoRowsAs(ErrConflict)` for explicit guarded writes.
 - `Returning(...)` is PostgreSQL-only in the current implementation.
@@ -956,9 +1032,10 @@ _, err := orm.DeleteBy(ctx, db.Table("users"), WithProfile(), BioLike("%python%"
 ## Limitations and caveats
 
 - Reads only support struct destinations and `map[string]any`. Pointer destinations are not supported.
-- Writes only support non-pointer struct values and `map[string]any`.
+- Writes only support non-pointer struct values and `map[string]any`; `InsertMany` supports slices of those shapes.
 - Generic `Update` only supports primary-key-based updates through `WherePK()`. For arbitrary predicates, use `UpdateBy` or `UpdateByReturning`.
 - Generic `Upsert` can use `WherePK()`, `ConflictColumns(...)`, `ConflictConstraint(...)`, or `ConflictTargetRaw(...)`.
+- Generic `InsertMany` is insert-only and rejects conflict/upsert and assignment options.
 - Scoped helpers are the recommended bridge when you want arbitrary predicates, joins, or `DELETE` while still keeping generic read/write helpers as the main public API.
 - Struct `Update` and `Upsert` depend on `db:"...,pk"` tags. Without them, `WherePK()` has no primary-key columns to use.
 - Since generic writes take struct values, a `TableName() string` override must be available on the value type. A pointer-receiver-only `TableName` method is not picked up here.

--- a/docs/policy-dsl.md
+++ b/docs/policy-dsl.md
@@ -20,6 +20,48 @@ Policy checks:
 - Required filters: configured columns must be present in predicates.
 - PII: selecting configured columns emits a warning and should include an access reason.
 
+Registered policies are checked for every table visible in a `QueryPlan`, including joined tables.
+When more than one policy table requires the same predicate column, qualify the predicate so the
+scope is unambiguous:
+
+```go
+err := orm.RegisterTablePolicy(orm.TablePolicy{
+    Table:        "users",
+    TenantColumn: "tenant_id",
+    TenantMode:   orm.PolicyModeBlock,
+})
+if err != nil {
+    return err
+}
+err = orm.RegisterTablePolicy(orm.TablePolicy{
+    Table:        "memberships",
+    TenantColumn: "tenant_id",
+    TenantMode:   orm.PolicyModeBlock,
+})
+if err != nil {
+    return err
+}
+
+plan, err := db.Table("users").
+    Select("users.id").
+    Join("memberships", "users.id", "=", "memberships.user_id").
+    Where("users.tenant_id", tenantID).
+    Where("memberships.tenant_id", tenantID).
+    Limit(50).
+    Plan(ctx)
+```
+
+Use `RequiredFilter` for parent scopes that must always be visible alongside tenant scope:
+
+```go
+err := orm.Model(FilingCase{}).
+    Table("filing_cases").
+    TenantScoped("tenant_id", orm.PolicyModeBlock).
+    RequiredFilter("client_company_id", "workplace_id").
+    PolicyMode(orm.PolicyModeBlock).
+    Register()
+```
+
 Soft delete helpers:
 
 ```go

--- a/docs/query-plan.md
+++ b/docs/query-plan.md
@@ -42,4 +42,12 @@ Important fields:
 - `analysis_precision`: `precise`, `partial`, or `unsupported`.
 
 Raw SQL can be wrapped with `query.NewRawPlan(sql, args...)`. Raw plans are useful for review, but
-they are high risk because Goquent cannot fully inspect arbitrary SQL.
+they are high risk because Goquent cannot fully inspect arbitrary SQL. When executing raw
+projections through `orm.SelectOne` or `orm.SelectAll`, use a DB copy with an approval reason and
+touched-table metadata so the review artifact explains the escape hatch:
+
+```go
+plan, err := db.RequireRawApproval("reviewed audit snapshot aggregation").
+    TouchedTables("audit_snapshots", "snapshot_items", "document_versions").
+    RawPlan(ctx, sqlText, tenantID)
+```

--- a/docs/review-cli.md
+++ b/docs/review-cli.md
@@ -11,17 +11,49 @@ go run ./cmd/goquent review --format github ./...
 Useful flags:
 
 - `--fail-on low|medium|high|destructive|blocked`: return exit code `1` at or above threshold.
+- `--fail-on-precision partial|unsupported`: return exit code `1` when static review precision is
+  at or above the selected limitation.
 - `--format pretty|json|github`: select human, machine, or GitHub annotation output.
 - `--show-suppressed`: include suppressed findings in the main output.
 - `--manifest path`: include manifest freshness status.
-- `--require-fresh-manifest`: return exit code `3` if manifest status is stale.
+- `--schema path`, `--policy path`, `--code path`, `--database-schema path`: current inputs used to
+  verify manifest freshness during review.
+- `--require-fresh-manifest`: return exit code `3` if the manifest is missing, stale, or
+  unverified against current inputs.
+- `--config path`: load JSON review defaults, rule overrides, and config suppressions.
 
 Exit codes:
 
 - `0`: no findings at or above the threshold.
 - `1`: findings reached the selected threshold.
 - `2`: parse, input, or configuration error.
-- `3`: review required a fresh manifest and the manifest was stale.
+- `3`: review required a fresh manifest and the manifest was missing, stale, or unverified.
+
+Config example:
+
+```json
+{
+  "manifest": "goquent.manifest.json",
+  "schema": "schema.json",
+  "policy": "policies.json",
+  "code": ["./internal/db"],
+  "require_fresh_manifest": true,
+  "fail_on": "high",
+  "fail_on_precision": "partial",
+  "rules": {
+    "LIMIT_MISSING": {"severity": "medium", "enabled": true}
+  },
+  "suppressions": [
+    {
+      "code": "LIMIT_MISSING",
+      "path": "internal/admin/export.go",
+      "reason": "admin export is bounded by caller authorization and audit logging",
+      "owner": "platform",
+      "expires": "2026-08-01"
+    }
+  ]
+}
+```
 
 CI example:
 
@@ -38,7 +70,13 @@ jobs:
           go-version-file: go.mod
       - run: go test ./...
       - run: go run ./cmd/goquent manifest verify --manifest goquent.manifest.json --schema schema.json --policy policies.json
-      - run: go run ./cmd/goquent review --format github --fail-on high --manifest goquent.manifest.json --require-fresh-manifest ./...
+      - run: >
+          go run ./cmd/goquent review --format github --fail-on high
+          --manifest goquent.manifest.json
+          --schema schema.json
+          --policy policies.json
+          --require-fresh-manifest
+          ./...
 ```
 
 Review output should be copied into PR comments for database-affecting changes, especially

--- a/docs/risk-engine.md
+++ b/docs/risk-engine.md
@@ -29,6 +29,11 @@ You can run the engine directly:
 result := orm.DefaultRiskEngine.CheckQuery(plan)
 ```
 
+Broad write detection is conservative. Without table key metadata, only `id` and qualified `*.id`
+predicates are treated as narrow. Foreign-key-looking columns such as `tenant_id` are not treated
+as primary-key-like by name alone. When review has manifest metadata, complete primary-key or
+unique-index predicates can be treated as narrow, including composite keys.
+
 Risk rules can be customized for local policy:
 
 ```go

--- a/docs/static-review-limits.md
+++ b/docs/static-review-limits.md
@@ -35,6 +35,8 @@ Treat it as a prompt to add a runtime `QueryPlan`, reduce dynamic SQL, or add fo
 Static review is strongest when:
 
 - Goquent builder calls are inline and explicit.
+- `goquent review` receives a fresh manifest and current schema/policy inputs so tenant, soft
+  delete, PII, required-filter, and unique-key metadata can be checked.
 - Query plans are checked into artifacts or generated in tests.
 - Raw SQL is isolated in `.sql` files for review.
 - Suppressions include reasons and expiration dates.

--- a/docs/suppression-and-approval.md
+++ b/docs/suppression-and-approval.md
@@ -25,6 +25,22 @@ Inline suppressions are supported by the review CLI:
 err := db.Table("users").Where("tenant_id", tenantID).Get(&rows)
 ```
 
+Config suppressions are supported by `goquent review --config`:
+
+```json
+{
+  "suppressions": [
+    {
+      "code": "LIMIT_MISSING",
+      "path": "internal/admin/export.go",
+      "reason": "admin export is bounded by caller authorization and audit logging",
+      "owner": "data-platform",
+      "expires": "2026-08-01"
+    }
+  ]
+}
+```
+
 Suppression cannot hide non-suppressible findings such as blocked updates or deletes without a
 predicate.
 

--- a/orm/driver/driver.go
+++ b/orm/driver/driver.go
@@ -71,7 +71,12 @@ func Open(driverName, dsn string, maxOpen, maxIdle int, lifetime time.Duration) 
 }
 
 // Close closes the underlying DB.
-func (d *Driver) Close() error { return d.DB.Close() }
+func (d *Driver) Close() error {
+	if d == nil || d.DB == nil {
+		return nil
+	}
+	return d.DB.Close()
+}
 
 // Tx wraps sql.Tx for transaction handling.
 type Tx struct{ *sql.Tx }

--- a/orm/errors.go
+++ b/orm/errors.go
@@ -1,0 +1,58 @@
+package orm
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is returned by one-row read helpers when no row is available.
+//
+// It aliases sql.ErrNoRows for compatibility with existing callers.
+var ErrNotFound = sql.ErrNoRows
+
+// ErrConflict represents an explicit optimistic-concurrency or stale-write
+// conflict chosen by the caller.
+var ErrConflict = errors.New("goquent: conflict")
+
+// ErrRowsAffected reports that a write did not affect the requested number of
+// rows.
+var ErrRowsAffected = errors.New("goquent: unexpected rows affected")
+
+// RowsAffectedError describes a failed rows-affected expectation.
+type RowsAffectedError struct {
+	Expected int64
+	Actual   int64
+	Cause    error
+}
+
+func (e RowsAffectedError) Error() string {
+	if e.Cause != nil && !errors.Is(e.Cause, ErrRowsAffected) {
+		return fmt.Sprintf("%s: expected %d row(s), affected %d: %v", ErrRowsAffected, e.Expected, e.Actual, e.Cause)
+	}
+	return fmt.Sprintf("%s: expected %d row(s), affected %d", ErrRowsAffected, e.Expected, e.Actual)
+}
+
+func (e RowsAffectedError) Unwrap() error {
+	if e.Cause != nil {
+		return e.Cause
+	}
+	return ErrRowsAffected
+}
+
+func (e RowsAffectedError) Is(target error) bool {
+	if target == ErrRowsAffected {
+		return true
+	}
+	return e.Cause != nil && errors.Is(e.Cause, target)
+}
+
+// IsNotFound reports whether err represents a no-row result.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound) || errors.Is(err, sql.ErrNoRows)
+}
+
+// IsConflict reports whether err represents an explicit write conflict.
+func IsConflict(err error) bool {
+	return errors.Is(err, ErrConflict)
+}

--- a/orm/json.go
+++ b/orm/json.go
@@ -26,6 +26,25 @@ func JSONNull[T any]() JSONField[T] {
 	return JSONField[T]{}
 }
 
+// EncodeJSON marshals v for JSON/JSONB or text-JSON columns.
+func EncodeJSON(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeJSON decodes a JSON/JSONB or text-JSON database value. NULL returns
+// fallback without error.
+func DecodeJSON[T any](src any, fallback T) (T, error) {
+	var field JSONField[T]
+	if err := field.Scan(src); err != nil {
+		return fallback, err
+	}
+	return field.OrDefault(fallback), nil
+}
+
 // Scan implements sql.Scanner.
 func (j *JSONField[T]) Scan(src any) error {
 	if j == nil {

--- a/orm/json_test.go
+++ b/orm/json_test.go
@@ -40,6 +40,32 @@ func TestJSONFieldScanValueDefaultAndValidate(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeJSONHelpers(t *testing.T) {
+	encoded, err := EncodeJSON(jsonSummary{Status: "ok", Count: 2})
+	if err != nil {
+		t.Fatalf("EncodeJSON: %v", err)
+	}
+	if !strings.Contains(encoded, `"status":"ok"`) {
+		t.Fatalf("encoded=%s", encoded)
+	}
+
+	decoded, err := DecodeJSON([]byte(encoded), jsonSummary{Status: "fallback"})
+	if err != nil {
+		t.Fatalf("DecodeJSON: %v", err)
+	}
+	if decoded.Status != "ok" || decoded.Count != 2 {
+		t.Fatalf("decoded=%+v", decoded)
+	}
+
+	fallback, err := DecodeJSON(nil, jsonSummary{Status: "fallback"})
+	if err != nil {
+		t.Fatalf("DecodeJSON nil: %v", err)
+	}
+	if fallback.Status != "fallback" {
+		t.Fatalf("fallback=%+v", fallback)
+	}
+}
+
 func TestJSONFieldNullAndNullableStrings(t *testing.T) {
 	field := JSONOf(jsonSummary{Status: "ok"})
 	if err := field.Scan(nil); err != nil {

--- a/orm/manifest/manifest.go
+++ b/orm/manifest/manifest.go
@@ -22,6 +22,8 @@ const (
 	Version           = "1"
 	Generator         = "goquent"
 	WarningStale      = "MANIFEST_STALE"
+	WarningUnverified = "MANIFEST_UNVERIFIED"
+	WarningRequired   = "MANIFEST_REQUIRED"
 	WarningUnreadable = "MANIFEST_UNREADABLE"
 )
 

--- a/orm/meta.go
+++ b/orm/meta.go
@@ -32,6 +32,7 @@ func newFieldMeta(col string, index []int) *fieldMeta {
 type typeMeta struct {
 	FieldsByName map[string]*fieldMeta
 	FieldsByNorm map[string]*fieldMeta
+	Fields       []*fieldMeta
 	PKCols       []string
 }
 
@@ -107,6 +108,7 @@ func getTypeMeta(t reflect.Type) (*typeMeta, error) {
 		}
 		m.FieldsByName[col] = fm
 		m.FieldsByNorm[normalize(col)] = fm
+		m.Fields = append(m.Fields, fm)
 	}
 	metaCache.Store(t, m)
 	return m, nil

--- a/orm/migration/status.go
+++ b/orm/migration/status.go
@@ -1,0 +1,425 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/faciam-dev/goquent/orm/driver"
+)
+
+// StatusExecutor is the read surface used by ReadStatus.
+type StatusExecutor interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// StatusOptions configures the migration status table reader.
+type StatusOptions struct {
+	Table           string
+	VersionColumn   string
+	DirtyColumn     string
+	AppliedAtColumn string
+}
+
+// StatusOption configures ReadStatus.
+type StatusOption func(*StatusOptions)
+
+// AppliedMigration is one row read from the migration status table.
+type AppliedMigration struct {
+	Version   string     `json:"version"`
+	AppliedAt *time.Time `json:"applied_at,omitempty"`
+	Dirty     bool       `json:"dirty,omitempty"`
+}
+
+// Status is a lightweight best-effort view of migration table state.
+type Status struct {
+	Table         string             `json:"table"`
+	Exists        bool               `json:"exists"`
+	Applied       []AppliedMigration `json:"applied,omitempty"`
+	LatestApplied string             `json:"latest_applied,omitempty"`
+	Pending       []string           `json:"pending,omitempty"`
+	Dirty         bool               `json:"dirty,omitempty"`
+	Unknown       bool               `json:"unknown,omitempty"`
+	Warnings      []string           `json:"warnings,omitempty"`
+}
+
+// WithStatusTable sets the migration table name. The default is
+// schema_migrations.
+func WithStatusTable(table string) StatusOption {
+	return func(o *StatusOptions) { o.Table = table }
+}
+
+// WithStatusVersionColumn sets the version column. The default is version.
+func WithStatusVersionColumn(column string) StatusOption {
+	return func(o *StatusOptions) { o.VersionColumn = column }
+}
+
+// WithStatusDirtyColumn enables dirty-state detection from column.
+func WithStatusDirtyColumn(column string) StatusOption {
+	return func(o *StatusOptions) { o.DirtyColumn = column }
+}
+
+// WithStatusAppliedAtColumn reads an optional applied-at timestamp column.
+func WithStatusAppliedAtColumn(column string) StatusOption {
+	return func(o *StatusOptions) { o.AppliedAtColumn = column }
+}
+
+// ReadStatus reads the migration table state and compares it with desired
+// versions supplied by the caller. It is intended for readiness checks, not as
+// a complete schema drift detector.
+func ReadStatus(ctx context.Context, exec StatusExecutor, dialect driver.Dialect, desired []string, opts ...StatusOption) (Status, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg := defaultStatusOptions()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	cfg.normalize()
+	status := Status{Table: cfg.Table}
+	desired = normalizeDesiredVersions(desired)
+	if exec == nil {
+		return status, fmt.Errorf("goquent: migration status executor is required")
+	}
+	if dialect == nil {
+		return status, fmt.Errorf("goquent: migration status dialect is required")
+	}
+
+	exists, err := migrationStatusTableExists(ctx, exec, dialect, cfg.Table)
+	if err != nil {
+		return status, err
+	}
+	status.Exists = exists
+	if !exists {
+		status.Pending = desired
+		return status, nil
+	}
+
+	applied, err := readAppliedMigrations(ctx, exec, dialect, cfg)
+	if err != nil {
+		return status, err
+	}
+	sort.SliceStable(applied, func(i, j int) bool {
+		return applied[i].Version < applied[j].Version
+	})
+	status.Applied = applied
+	if len(applied) > 0 {
+		status.LatestApplied = applied[len(applied)-1].Version
+	}
+	for _, row := range applied {
+		if row.Dirty {
+			status.Dirty = true
+			break
+		}
+	}
+	status.Pending = pendingMigrationVersions(desired, applied)
+	status.Warnings = migrationStatusWarnings(desired, applied)
+	if len(status.Warnings) > 0 {
+		status.Unknown = true
+	}
+	return status, nil
+}
+
+func defaultStatusOptions() StatusOptions {
+	return StatusOptions{
+		Table:         "schema_migrations",
+		VersionColumn: "version",
+	}
+}
+
+func (o *StatusOptions) normalize() {
+	o.Table = strings.TrimSpace(o.Table)
+	if o.Table == "" {
+		o.Table = "schema_migrations"
+	}
+	o.VersionColumn = strings.TrimSpace(o.VersionColumn)
+	if o.VersionColumn == "" {
+		o.VersionColumn = "version"
+	}
+	o.DirtyColumn = strings.TrimSpace(o.DirtyColumn)
+	o.AppliedAtColumn = strings.TrimSpace(o.AppliedAtColumn)
+}
+
+func migrationStatusTableExists(ctx context.Context, exec StatusExecutor, dialect driver.Dialect, table string) (bool, error) {
+	switch dialect.(type) {
+	case driver.PostgresDialect:
+		return queryStatusBool(ctx, exec, "SELECT to_regclass($1) IS NOT NULL", table)
+	case driver.MySQLDialect:
+		schema, name := splitMySQLStatusTable(table)
+		if schema == "" {
+			return queryStatusCount(ctx, exec, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?", name)
+		}
+		return queryStatusCount(ctx, exec, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", schema, name)
+	default:
+		return false, fmt.Errorf("goquent: migration status is not supported on dialect: %T", dialect)
+	}
+}
+
+func queryStatusBool(ctx context.Context, exec StatusExecutor, sqlStr string, args ...any) (bool, error) {
+	rows, err := exec.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return false, rows.Err()
+	}
+	var exists bool
+	if err := rows.Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, rows.Err()
+}
+
+func queryStatusCount(ctx context.Context, exec StatusExecutor, sqlStr string, args ...any) (bool, error) {
+	rows, err := exec.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return false, rows.Err()
+	}
+	var count int64
+	if err := rows.Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, rows.Err()
+}
+
+func readAppliedMigrations(ctx context.Context, exec StatusExecutor, dialect driver.Dialect, cfg StatusOptions) ([]AppliedMigration, error) {
+	versionSQL, err := quoteStatusIdentifierPath(dialect, cfg.VersionColumn)
+	if err != nil {
+		return nil, err
+	}
+	selectCols := []string{versionSQL}
+	if cfg.AppliedAtColumn != "" {
+		col, err := quoteStatusIdentifierPath(dialect, cfg.AppliedAtColumn)
+		if err != nil {
+			return nil, err
+		}
+		selectCols = append(selectCols, col)
+	}
+	if cfg.DirtyColumn != "" {
+		col, err := quoteStatusIdentifierPath(dialect, cfg.DirtyColumn)
+		if err != nil {
+			return nil, err
+		}
+		selectCols = append(selectCols, col)
+	}
+	tableSQL, err := quoteStatusIdentifierPath(dialect, cfg.Table)
+	if err != nil {
+		return nil, err
+	}
+	sqlStr := fmt.Sprintf("SELECT %s FROM %s ORDER BY %s ASC", strings.Join(selectCols, ", "), tableSQL, versionSQL)
+	rows, err := exec.QueryContext(ctx, sqlStr)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var applied []AppliedMigration
+	for rows.Next() {
+		var versionRaw any
+		scanDst := []any{&versionRaw}
+		var appliedAtRaw any
+		var dirtyRaw any
+		if cfg.AppliedAtColumn != "" {
+			scanDst = append(scanDst, &appliedAtRaw)
+		}
+		if cfg.DirtyColumn != "" {
+			scanDst = append(scanDst, &dirtyRaw)
+		}
+		if err := rows.Scan(scanDst...); err != nil {
+			return nil, err
+		}
+		row := AppliedMigration{Version: statusString(versionRaw)}
+		if cfg.AppliedAtColumn != "" {
+			appliedAt, err := statusTime(appliedAtRaw)
+			if err != nil {
+				return nil, err
+			}
+			row.AppliedAt = appliedAt
+		}
+		if cfg.DirtyColumn != "" {
+			dirty, err := statusBool(dirtyRaw)
+			if err != nil {
+				return nil, err
+			}
+			row.Dirty = dirty
+		}
+		applied = append(applied, row)
+	}
+	return applied, rows.Err()
+}
+
+func statusString(src any) string {
+	switch v := src.(type) {
+	case nil:
+		return ""
+	case []byte:
+		return string(v)
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func statusBool(src any) (bool, error) {
+	switch v := src.(type) {
+	case nil:
+		return false, nil
+	case bool:
+		return v, nil
+	case int8:
+		return v != 0, nil
+	case int16:
+		return v != 0, nil
+	case int32:
+		return v != 0, nil
+	case int64:
+		return v != 0, nil
+	case int:
+		return v != 0, nil
+	case uint8:
+		return v != 0, nil
+	case uint16:
+		return v != 0, nil
+	case uint32:
+		return v != 0, nil
+	case uint64:
+		return v != 0, nil
+	case uint:
+		return v != 0, nil
+	case []byte:
+		return statusBoolString(string(v))
+	case string:
+		return statusBoolString(v)
+	default:
+		return false, fmt.Errorf("goquent: cannot convert migration dirty value %T to bool", src)
+	}
+}
+
+func statusBoolString(s string) (bool, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	switch s {
+	case "", "0", "false", "f", "no", "n":
+		return false, nil
+	case "1", "true", "t", "yes", "y":
+		return true, nil
+	default:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return false, fmt.Errorf("goquent: cannot convert migration dirty value %q to bool", s)
+		}
+		return n != 0, nil
+	}
+}
+
+func statusTime(src any) (*time.Time, error) {
+	switch v := src.(type) {
+	case nil:
+		return nil, nil
+	case time.Time:
+		t := v
+		return &t, nil
+	case []byte:
+		return parseStatusTime(string(v))
+	case string:
+		return parseStatusTime(v)
+	default:
+		return nil, fmt.Errorf("goquent: cannot convert migration applied-at value %T to time", src)
+	}
+}
+
+func parseStatusTime(s string) (*time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999", "2006-01-02 15:04:05"} {
+		t, err := time.Parse(layout, s)
+		if err == nil {
+			return &t, nil
+		}
+	}
+	return nil, fmt.Errorf("goquent: cannot parse migration applied-at value %q", s)
+}
+
+func normalizeDesiredVersions(desired []string) []string {
+	seen := make(map[string]struct{}, len(desired))
+	out := make([]string, 0, len(desired))
+	for _, version := range desired {
+		version = strings.TrimSpace(version)
+		if version == "" {
+			continue
+		}
+		if _, ok := seen[version]; ok {
+			continue
+		}
+		seen[version] = struct{}{}
+		out = append(out, version)
+	}
+	return out
+}
+
+func pendingMigrationVersions(desired []string, applied []AppliedMigration) []string {
+	appliedSet := make(map[string]struct{}, len(applied))
+	for _, row := range applied {
+		appliedSet[row.Version] = struct{}{}
+	}
+	pending := make([]string, 0, len(desired))
+	for _, version := range desired {
+		if _, ok := appliedSet[version]; !ok {
+			pending = append(pending, version)
+		}
+	}
+	return pending
+}
+
+func migrationStatusWarnings(desired []string, applied []AppliedMigration) []string {
+	if len(desired) == 0 {
+		return nil
+	}
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, version := range desired {
+		desiredSet[version] = struct{}{}
+	}
+	var warnings []string
+	for _, row := range applied {
+		if _, ok := desiredSet[row.Version]; ok {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf("applied migration %s is not present in desired versions; status is best-effort and drift is unknown", row.Version))
+	}
+	return warnings
+}
+
+func splitMySQLStatusTable(table string) (string, string) {
+	parts := strings.Split(table, ".")
+	if len(parts) == 1 {
+		return "", strings.TrimSpace(parts[0])
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[len(parts)-1])
+}
+
+func quoteStatusIdentifierPath(dialect driver.Dialect, ident string) (string, error) {
+	parts := strings.Split(ident, ".")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("goquent: identifier path is required")
+	}
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", fmt.Errorf("goquent: identifier path contains an empty part")
+		}
+		quoted[i] = dialect.QuoteIdent(part)
+	}
+	return strings.Join(quoted, "."), nil
+}

--- a/orm/migration/status_test.go
+++ b/orm/migration/status_test.go
@@ -1,0 +1,167 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/faciam-dev/goquent/orm/driver"
+)
+
+func newStatusMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db, mock
+}
+
+func TestReadStatusPostgresAppliedRowsAndPending(t *testing.T) {
+	db, mock := newStatusMockDB(t)
+	appliedAt := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT to_regclass($1) IS NOT NULL")).
+		WithArgs("schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "version", "applied_at" FROM "schema_migrations" ORDER BY "version" ASC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"version", "applied_at"}).
+			AddRow("202605220001", appliedAt).
+			AddRow("202605220002", appliedAt.Add(time.Minute)))
+
+	status, err := ReadStatus(
+		context.Background(),
+		db,
+		driver.PostgresDialect{},
+		[]string{"202605220001", "202605220002", "202605220003"},
+		WithStatusAppliedAtColumn("applied_at"),
+	)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !status.Exists || status.LatestApplied != "202605220002" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if len(status.Applied) != 2 || status.Applied[0].AppliedAt == nil {
+		t.Fatalf("expected applied timestamps: %+v", status.Applied)
+	}
+	if len(status.Pending) != 1 || status.Pending[0] != "202605220003" {
+		t.Fatalf("unexpected pending: %+v", status.Pending)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestReadStatusMissingTableReturnsPendingDesired(t *testing.T) {
+	db, mock := newStatusMockDB(t)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT to_regclass($1) IS NOT NULL")).
+		WithArgs("schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	status, err := ReadStatus(
+		context.Background(),
+		db,
+		driver.PostgresDialect{},
+		[]string{"001", "002"},
+	)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status.Exists {
+		t.Fatalf("expected missing table: %+v", status)
+	}
+	if len(status.Pending) != 2 || status.Pending[0] != "001" || status.Pending[1] != "002" {
+		t.Fatalf("unexpected pending: %+v", status.Pending)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestReadStatusDirtyColumnDetection(t *testing.T) {
+	db, mock := newStatusMockDB(t)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT to_regclass($1) IS NOT NULL")).
+		WithArgs("schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "version", "dirty" FROM "schema_migrations" ORDER BY "version" ASC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).
+			AddRow("001", false).
+			AddRow("002", true))
+
+	status, err := ReadStatus(
+		context.Background(),
+		db,
+		driver.PostgresDialect{},
+		[]string{"001", "002"},
+		WithStatusDirtyColumn("dirty"),
+	)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !status.Dirty || !status.Applied[1].Dirty {
+		t.Fatalf("expected dirty status: %+v", status)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestReadStatusWarnsOnExtraAppliedVersion(t *testing.T) {
+	db, mock := newStatusMockDB(t)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT to_regclass($1) IS NOT NULL")).
+		WithArgs("schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "version" FROM "schema_migrations" ORDER BY "version" ASC`)).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).
+			AddRow("001").
+			AddRow("999"))
+
+	status, err := ReadStatus(
+		context.Background(),
+		db,
+		driver.PostgresDialect{},
+		[]string{"001"},
+	)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !status.Unknown || len(status.Warnings) != 1 {
+		t.Fatalf("expected unknown warning: %+v", status)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestReadStatusMySQLSchemaQualifiedTable(t *testing.T) {
+	db, mock := newStatusMockDB(t)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?")).
+		WithArgs("app", "schema_migrations").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT `version` FROM `app`.`schema_migrations` ORDER BY `version` ASC")).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow("001"))
+
+	status, err := ReadStatus(
+		context.Background(),
+		db,
+		driver.MySQLDialect{},
+		[]string{"001", "002"},
+		WithStatusTable("app.schema_migrations"),
+	)
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !status.Exists || status.LatestApplied != "001" {
+		t.Fatalf("unexpected mysql status: %+v", status)
+	}
+	if len(status.Pending) != 1 || status.Pending[0] != "002" {
+		t.Fatalf("unexpected pending: %+v", status.Pending)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/orm/operation/spec.go
+++ b/orm/operation/spec.go
@@ -31,6 +31,7 @@ var (
 	ErrForbiddenField          = errors.New("goquent operation: forbidden field")
 	ErrInvalidFilter           = errors.New("goquent operation: invalid filter")
 	ErrInvalidOrder            = errors.New("goquent operation: invalid order")
+	ErrValueRefMissing         = errors.New("goquent operation: value_ref missing")
 	ErrRequiredFilterMissing   = errors.New("goquent operation: required filter missing")
 	ErrPIIAccessReasonRequired = errors.New("goquent operation: PII access reason required")
 	ErrStaleManifest           = errors.New("goquent operation: stale manifest")
@@ -221,6 +222,14 @@ func validate(spec OperationSpec, opts Options) (validationResult, error) {
 		}
 		if !supportedFilterOp(filter.Op) {
 			return validationResult{}, fmt.Errorf("%w: unsupported operator %q", ErrInvalidFilter, filter.Op)
+		}
+		if strings.TrimSpace(filter.ValueRef) != "" {
+			if opts.Values == nil {
+				return validationResult{}, fmt.Errorf("%w: %s", ErrValueRefMissing, filter.ValueRef)
+			}
+			if _, ok := opts.Values[filter.ValueRef]; !ok {
+				return validationResult{}, fmt.Errorf("%w: %s", ErrValueRefMissing, filter.ValueRef)
+			}
 		}
 	}
 	for _, order := range spec.OrderBy {

--- a/orm/operation/spec_test.go
+++ b/orm/operation/spec_test.go
@@ -77,6 +77,15 @@ func TestValidateRejectsUnsafeSpec(t *testing.T) {
 	if !errors.Is(err, ErrForbiddenField) {
 		t.Fatalf("expected forbidden field rejection, got %v", err)
 	}
+	_, err = Validate(OperationSpec{
+		Operation: OperationSelect,
+		Model:     "Order",
+		Select:    []string{"id"},
+		Filters:   []FilterSpec{{Field: "tenant_id", Op: "=", ValueRef: "current_tenant"}},
+	}, Options{Manifest: m})
+	if !errors.Is(err, ErrValueRefMissing) {
+		t.Fatalf("expected missing value_ref rejection, got %v", err)
+	}
 }
 
 func TestValidatePolicyAndPII(t *testing.T) {

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -13,8 +13,8 @@ import (
 	"github.com/faciam-dev/goquent/orm/query"
 )
 
-// executor abstracts sql.DB and sql.Tx.
-type executor interface {
+// Executor abstracts sql.DB, sql.Tx, and compatible transaction wrappers.
+type Executor interface {
 	// Query runs a SQL statement returning multiple rows.
 	Query(query string, args ...any) (*sql.Rows, error)
 	// QueryContext is the context-aware version of Query.
@@ -32,9 +32,10 @@ type executor interface {
 // DB provides main ORM interface.
 type DB struct {
 	drv         *driver.Driver
-	exec        executor
+	exec        Executor
 	scanOpts    ScanOptions
 	rawApproval *query.Approval
+	rawTables   []string
 	rawErr      error
 }
 
@@ -67,7 +68,7 @@ func defaultDialect(name string) driver.Dialect {
 	return driver.MySQLDialect{}
 }
 
-func newDB(d *driver.Driver, exec executor, opts ...Option) *DB {
+func newDB(d *driver.Driver, exec Executor, opts ...Option) *DB {
 	db := &DB{drv: d, exec: exec, scanOpts: ScanOptions{BoolPolicy: BoolCompat}}
 	for _, o := range opts {
 		o(db)
@@ -90,10 +91,47 @@ func (db *DB) RequireRawApproval(reason string) *DB {
 	return &next
 }
 
+// TouchedTables returns a shallow DB copy that annotates raw SQL QueryPlans
+// with the tables the caller reviewed.
+func (db *DB) TouchedTables(tables ...string) *DB {
+	next := *db
+	next.rawTables = append([]string(nil), db.rawTables...)
+	seen := make(map[string]struct{}, len(next.rawTables)+len(tables))
+	for _, table := range next.rawTables {
+		seen[strings.ToLower(strings.TrimSpace(table))] = struct{}{}
+	}
+	for _, table := range tables {
+		table = strings.TrimSpace(table)
+		if table == "" {
+			continue
+		}
+		key := strings.ToLower(table)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		next.rawTables = append(next.rawTables, table)
+	}
+	return &next
+}
+
 // NewDB wraps an existing sql.DB with a dialect into DB.
 func NewDB(sqlDB *sql.DB, dialect driver.Dialect, opts ...Option) *DB {
 	d := &driver.Driver{DB: sqlDB, Dialect: dialect}
 	return newDB(d, sqlDB, opts...)
+}
+
+// NewDBWithExecutor wraps an existing sql.DB/sql.Tx-compatible executor with a
+// dialect into DB. The returned DB does not own the executor; Close is a no-op
+// unless the executor was created by Open/OpenWithDriver/NewDB with *sql.DB.
+func NewDBWithExecutor(exec Executor, dialect driver.Dialect, opts ...Option) *DB {
+	d := &driver.Driver{Dialect: dialect}
+	return newDB(d, exec, opts...)
+}
+
+// NewTxDB wraps an existing sql.Tx with a dialect into DB.
+func NewTxDB(tx *sql.Tx, dialect driver.Dialect, opts ...Option) *DB {
+	return NewDBWithExecutor(tx, dialect, opts...)
 }
 
 // Open opens a MySQL database with default pooling. Deprecated: use
@@ -140,12 +178,28 @@ func OpenWithDriverOptions(driverName, dsn string, opts ...Option) (*DB, error) 
 	return newDB(drv, drv.DB, opts...), nil
 }
 
-// Close closes underlying DB.
-func (db *DB) Close() error { return db.drv.Close() }
+// Close closes the owned underlying DB. DB values created around an external
+// executor or transaction do not own a sql.DB, so Close is a no-op for them.
+func (db *DB) Close() error {
+	if db == nil || db.drv == nil || db.drv.DB == nil {
+		return nil
+	}
+	return db.drv.Close()
+}
 
 // newTransactionDB wraps a sql.Tx in a DB instance bound to the same driver.
 func (db *DB) newTransactionDB(tx *sql.Tx) *DB {
-	return &DB{drv: db.drv, exec: tx, scanOpts: db.scanOpts, rawApproval: db.rawApproval, rawErr: db.rawErr}
+	return &DB{drv: db.drv, exec: tx, scanOpts: db.scanOpts, rawApproval: db.rawApproval, rawTables: append([]string(nil), db.rawTables...), rawErr: db.rawErr}
+}
+
+// WrapTx returns a DB copy that executes through tx while preserving this DB's
+// dialect, scan options, and raw-SQL approval state.
+func (db *DB) WrapTx(tx *sql.Tx, opts ...Option) *DB {
+	next := db.newTransactionDB(tx)
+	for _, o := range opts {
+		o(next)
+	}
+	return next
 }
 
 // Tx represents a transaction-scoped DB wrapper.
@@ -200,6 +254,12 @@ func (db *DB) Table(name string) *query.Query {
 	return query.New(db.exec, name, db.drv.Dialect)
 }
 
+// TablePath creates a query for a schema-qualified or otherwise
+// path-qualified table name.
+func (db *DB) TablePath(parts ...string) *query.Query {
+	return db.Table(strings.Join(parts, "."))
+}
+
 func (db *DB) rawPlan(ctx context.Context, q string, args ...any) (*query.QueryPlan, error) {
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
@@ -213,6 +273,9 @@ func (db *DB) rawPlan(ctx context.Context, q string, args ...any) (*query.QueryP
 	if db.rawApproval != nil {
 		copied := *db.rawApproval
 		plan.Approval = &copied
+	}
+	for _, table := range db.rawTables {
+		plan.Tables = append(plan.Tables, query.TableRef{Name: table})
 	}
 	return plan, nil
 }

--- a/orm/orm_raw_test.go
+++ b/orm/orm_raw_test.go
@@ -74,3 +74,21 @@ func TestDeprecatedQueryRowExecutesApprovedRawSQL(t *testing.T) {
 		t.Fatalf("expected no rejected sentinel query, got %#v", exec.queryRowsContext)
 	}
 }
+
+func TestRawPlanIncludesTouchedTables(t *testing.T) {
+	exec := &rawQueryRowExecutor{}
+	db := newDB(&driver.Driver{Dialect: driver.MySQLDialect{}}, exec).
+		RequireRawApproval("reviewed work item projection").
+		TouchedTables("work_items", "users", "users")
+
+	plan, err := db.RawPlan(context.Background(), "SELECT * FROM work_items JOIN users ON users.id = work_items.user_id")
+	if err != nil {
+		t.Fatalf("RawPlan: %v", err)
+	}
+	if len(plan.Tables) != 2 || plan.Tables[0].Name != "work_items" || plan.Tables[1].Name != "users" {
+		t.Fatalf("tables=%#v", plan.Tables)
+	}
+	if plan.Approval == nil || plan.Approval.Reason == "" {
+		t.Fatalf("approval=%#v", plan.Approval)
+	}
+}

--- a/orm/query/plan.go
+++ b/orm/query/plan.go
@@ -158,6 +158,31 @@ type QueryPlan struct {
 	Metadata           map[string]any    `json:"metadata,omitempty"`
 }
 
+// MetadataTableRisk stores []TableRiskMetadata in QueryPlan.Metadata.
+const MetadataTableRisk = "table_risk_metadata"
+
+// TableRiskMetadata gives the risk engine table key context without depending
+// on the manifest package.
+type TableRiskMetadata struct {
+	Table                 string     `json:"table"`
+	PrimaryKeyColumns     []string   `json:"primary_key_columns,omitempty"`
+	UniqueIndexes         [][]string `json:"unique_indexes,omitempty"`
+	TenantColumn          string     `json:"tenant_column,omitempty"`
+	SoftDeleteColumn      string     `json:"soft_delete_column,omitempty"`
+	RequiredFilterColumns []string   `json:"required_filter_columns,omitempty"`
+}
+
+// AttachTableRiskMetadata attaches table key metadata used by risk checks.
+func AttachTableRiskMetadata(plan *QueryPlan, metadata []TableRiskMetadata) {
+	if plan == nil || len(metadata) == 0 {
+		return
+	}
+	if plan.Metadata == nil {
+		plan.Metadata = make(map[string]any, 1)
+	}
+	plan.Metadata[MetadataTableRisk] = append([]TableRiskMetadata(nil), metadata...)
+}
+
 // RequiresApproval reports whether this plan needs explicit approval.
 func (p *QueryPlan) RequiresApproval() bool {
 	return p != nil && p.RequiredApproval

--- a/orm/query/plan_test.go
+++ b/orm/query/plan_test.go
@@ -167,6 +167,56 @@ func TestWhereCursorRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+func TestWhereCursorSupportsTrustedExpression(t *testing.T) {
+	plan, err := New(&recordingExec{}, "events", ormdriver.PostgresDialect{}).
+		SelectRaw("(entity_type || ':' || entity_id) AS entity_sort_key").
+		WhereCursorAfter([]CursorColumn{CursorDescExpr("(entity_type || ':' || entity_id)")}, "source:1").
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(plan.SQL, `(entity_type || ':' || entity_id) <`) {
+		t.Fatalf("expected raw cursor expression, sql=%q", plan.SQL)
+	}
+	if len(plan.Params) != 1 || plan.Params[0] != "source:1" {
+		t.Fatalf("params=%#v", plan.Params)
+	}
+}
+
+func TestPostgresJSONBPredicates(t *testing.T) {
+	plan, err := New(&recordingExec{}, "events", ormdriver.PostgresDialect{}).
+		Select("id").
+		WhereJSONText("payload", "reason", "initial_sync").
+		WhereJSONHasKey("payload", "cache_invalidated_at").
+		WhereJSONNotHasKey("payload", "ignored_at").
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	for _, want := range []string{`"payload" ->>`, `"payload" ?`, `NOT ("payload" ?`} {
+		if !strings.Contains(plan.SQL, want) {
+			t.Fatalf("expected %q in sql=%q", want, plan.SQL)
+		}
+	}
+	if len(plan.Params) != 4 ||
+		plan.Params[0] != "reason" ||
+		plan.Params[1] != "initial_sync" ||
+		plan.Params[2] != "cache_invalidated_at" ||
+		plan.Params[3] != "ignored_at" {
+		t.Fatalf("params=%#v", plan.Params)
+	}
+}
+
+func TestJSONBPredicatesRequirePostgres(t *testing.T) {
+	_, err := newPlanTestQuery(&recordingExec{}).
+		Select("id").
+		WhereJSONHasKey("payload", "reason").
+		Plan(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "only supported on PostgreSQL") {
+		t.Fatalf("expected postgres-only error, got %v", err)
+	}
+}
+
 func TestWritePlanSnapshots(t *testing.T) {
 	ctx := context.Background()
 

--- a/orm/query/policy.go
+++ b/orm/query/policy.go
@@ -132,7 +132,82 @@ func cloneTablePolicy(policy TablePolicy) TablePolicy {
 	return policy
 }
 
+type policyCheckContext struct {
+	ambiguousPredicateColumns map[string]bool
+}
+
+func checkPolicies(plan *QueryPlan, extra *TablePolicy) []Warning {
+	if plan == nil {
+		return nil
+	}
+
+	byTable := make(map[string]TablePolicy)
+	for _, policy := range RegisteredTablePolicies() {
+		byTable[normalizeTableName(policy.Table)] = policy
+	}
+	if extra != nil && strings.TrimSpace(extra.Table) != "" {
+		byTable[normalizeTableName(extra.Table)] = cloneTablePolicy(*extra)
+	}
+
+	keys := make([]string, 0, len(byTable))
+	for key := range byTable {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	policies := make([]TablePolicy, 0, len(keys))
+	for _, key := range keys {
+		policy := byTable[key]
+		if planTouchesTable(plan, policy.Table) {
+			policies = append(policies, policy)
+		}
+	}
+
+	ctx := newPolicyCheckContext(policies)
+	var warnings []Warning
+	for i := range policies {
+		policy := policies[i]
+		warnings = append(warnings, checkPolicyWithContext(plan, &policy, ctx)...)
+	}
+	return warnings
+}
+
+func newPolicyCheckContext(policies []TablePolicy) policyCheckContext {
+	columnOwners := make(map[string]map[string]struct{})
+	addOwner := func(table, column string) {
+		column = normalizeColumnName(column)
+		if column == "" {
+			return
+		}
+		table = normalizeTableName(table)
+		if columnOwners[column] == nil {
+			columnOwners[column] = make(map[string]struct{})
+		}
+		columnOwners[column][table] = struct{}{}
+	}
+
+	for _, policy := range policies {
+		addOwner(policy.Table, policy.TenantColumn)
+		addOwner(policy.Table, policy.SoftDeleteColumn)
+		for _, col := range policy.RequiredFilterColumns {
+			addOwner(policy.Table, col)
+		}
+	}
+
+	ambiguous := make(map[string]bool)
+	for col, owners := range columnOwners {
+		if len(owners) > 1 {
+			ambiguous[col] = true
+		}
+	}
+	return policyCheckContext{ambiguousPredicateColumns: ambiguous}
+}
+
 func checkPolicy(plan *QueryPlan, policy *TablePolicy) []Warning {
+	return checkPolicyWithContext(plan, policy, policyCheckContext{})
+}
+
+func checkPolicyWithContext(plan *QueryPlan, policy *TablePolicy, ctx policyCheckContext) []Warning {
 	if plan == nil || policy == nil || policy.Table == "" {
 		return nil
 	}
@@ -141,7 +216,7 @@ func checkPolicy(plan *QueryPlan, policy *TablePolicy) []Warning {
 	}
 
 	var warnings []Warning
-	if policy.TenantColumn != "" && policyAppliesToOperation(plan.Operation) && !hasPredicateColumn(plan, policy.TenantColumn) {
+	if policy.TenantColumn != "" && policyAppliesToOperation(plan.Operation) && !hasPolicyPredicateColumn(plan, policy.Table, policy.TenantColumn, !ctx.ambiguousPredicateColumns[normalizeColumnName(policy.TenantColumn)]) {
 		warnings = append(warnings, policyWarning(
 			WarningTenantFilterMissing,
 			policyModeLevel(policy.TenantMode, RiskHigh),
@@ -151,7 +226,7 @@ func checkPolicy(plan *QueryPlan, policy *TablePolicy) []Warning {
 		))
 	}
 	for _, col := range policy.RequiredFilterColumns {
-		if policyAppliesToOperation(plan.Operation) && !hasPredicateColumn(plan, col) {
+		if policyAppliesToOperation(plan.Operation) && !hasPolicyPredicateColumn(plan, policy.Table, col, !ctx.ambiguousPredicateColumns[normalizeColumnName(col)]) {
 			warnings = append(warnings, policyWarning(
 				WarningRequiredFilterMissing,
 				policyModeLevel(policy.RequiredFilterMode, RiskHigh),
@@ -161,7 +236,7 @@ func checkPolicy(plan *QueryPlan, policy *TablePolicy) []Warning {
 			))
 		}
 	}
-	if policy.SoftDeleteColumn != "" && policyAppliesToOperation(plan.Operation) && shouldRequireSoftDeleteFilter(plan) && !hasPredicateColumn(plan, policy.SoftDeleteColumn) {
+	if policy.SoftDeleteColumn != "" && policyAppliesToOperation(plan.Operation) && shouldRequireSoftDeleteFilter(plan, policy.Table) && !hasPolicyPredicateColumn(plan, policy.Table, policy.SoftDeleteColumn, !ctx.ambiguousPredicateColumns[normalizeColumnName(policy.SoftDeleteColumn)]) {
 		warnings = append(warnings, policyWarning(
 			WarningSoftDeleteFilterMissing,
 			policyModeLevel(policy.SoftDeleteMode, RiskMedium),
@@ -171,7 +246,7 @@ func checkPolicy(plan *QueryPlan, policy *TablePolicy) []Warning {
 		))
 	}
 	if plan.Operation == OperationSelect {
-		for _, col := range selectedPIIColumns(plan, policy.PIIColumns) {
+		for _, col := range selectedPIIColumnsForPolicy(plan, policy.Table, policy.PIIColumns) {
 			w := policyWarning(
 				WarningPIIColumnSelected,
 				policyModeLevel(policy.PIIMode, RiskMedium),
@@ -230,12 +305,17 @@ func planTouchesTable(plan *QueryPlan, table string) bool {
 }
 
 func hasPredicateColumn(plan *QueryPlan, column string) bool {
+	return hasPolicyPredicateColumn(plan, "", column, true)
+}
+
+func hasPolicyPredicateColumn(plan *QueryPlan, table, column string, allowUnqualified bool) bool {
 	target := normalizeColumnName(column)
+	qualifiers := tableQualifierSet(plan, table)
 	for _, predicate := range plan.Predicates {
-		if normalizeColumnName(predicate.Column) == target {
+		if predicateColumnMatches(predicate.Column, target, qualifiers, allowUnqualified) {
 			return true
 		}
-		if normalizeColumnName(predicate.ValueColumn) == target {
+		if predicateColumnMatches(predicate.ValueColumn, target, qualifiers, allowUnqualified) {
 			return true
 		}
 	}
@@ -243,18 +323,23 @@ func hasPredicateColumn(plan *QueryPlan, column string) bool {
 }
 
 func selectedPIIColumns(plan *QueryPlan, piiColumns []string) []string {
+	return selectedPIIColumnsForPolicy(plan, "", piiColumns)
+}
+
+func selectedPIIColumnsForPolicy(plan *QueryPlan, table string, piiColumns []string) []string {
 	if len(piiColumns) == 0 {
 		return nil
 	}
+	qualifiers := tableQualifierSet(plan, table)
 	selectedAll := false
-	selected := make(map[string]struct{})
+	selected := make([]string, 0, len(plan.Columns))
 	for _, column := range plan.Columns {
 		if strings.TrimSpace(column.Name) == "*" || strings.TrimSpace(column.Expression) == "*" {
 			selectedAll = true
 			continue
 		}
 		if column.Name != "" {
-			selected[normalizeColumnName(column.Name)] = struct{}{}
+			selected = append(selected, column.Name)
 		}
 	}
 	var out []string
@@ -263,20 +348,86 @@ func selectedPIIColumns(plan *QueryPlan, piiColumns []string) []string {
 			out = append(out, pii)
 			continue
 		}
-		if _, ok := selected[normalizeColumnName(pii)]; ok {
-			out = append(out, pii)
+		target := normalizeColumnName(pii)
+		for _, column := range selected {
+			if predicateColumnMatches(column, target, qualifiers, true) {
+				out = append(out, pii)
+				break
+			}
 		}
 	}
 	return out
 }
 
-func shouldRequireSoftDeleteFilter(plan *QueryPlan) bool {
+func shouldRequireSoftDeleteFilter(plan *QueryPlan, table string) bool {
 	if plan.Metadata != nil {
 		if v, ok := plan.Metadata["soft_delete"].(string); ok && v == "with_deleted" {
-			return false
+			if policyTable, ok := plan.Metadata["policy_table"].(string); !ok || normalizeTableName(policyTable) == normalizeTableName(table) {
+				return false
+			}
 		}
 	}
 	return true
+}
+
+func predicateColumnMatches(reference, target string, qualifiers map[string]struct{}, allowUnqualified bool) bool {
+	qualifier, name := splitColumnReference(reference)
+	if name == "" || name != target {
+		return false
+	}
+	if len(qualifiers) == 0 {
+		return true
+	}
+	if qualifier == "" {
+		return allowUnqualified
+	}
+	_, ok := qualifiers[qualifier]
+	return ok
+}
+
+func splitColumnReference(reference string) (string, string) {
+	reference = strings.TrimSpace(reference)
+	if reference == "" {
+		return "", ""
+	}
+	idx := strings.LastIndex(reference, ".")
+	if idx < 0 {
+		return "", normalizeColumnName(reference)
+	}
+	return normalizeIdentifierToken(reference[:idx]), normalizeColumnName(reference)
+}
+
+func tableQualifierSet(plan *QueryPlan, table string) map[string]struct{} {
+	if plan == nil || strings.TrimSpace(table) == "" {
+		return nil
+	}
+	target := normalizeTableName(table)
+	out := make(map[string]struct{})
+	for _, ref := range plan.Tables {
+		if normalizeTableName(ref.Name) != target {
+			continue
+		}
+		addTableQualifier(out, ref.Name)
+		addTableQualifier(out, ref.Alias)
+		name, alias := splitTableAlias(ref.Name)
+		addTableQualifier(out, name)
+		addTableQualifier(out, alias)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func addTableQualifier(out map[string]struct{}, value string) {
+	value = normalizeIdentifierToken(value)
+	if value == "" {
+		return
+	}
+	out[value] = struct{}{}
+	if idx := strings.LastIndex(value, "."); idx >= 0 && idx+1 < len(value) {
+		out[value[idx+1:]] = struct{}{}
+	}
 }
 
 func normalizeColumnName(column string) string {
@@ -294,15 +445,27 @@ func normalizeTableName(table string) string {
 	if table == "" {
 		return ""
 	}
+	table, _ = splitTableAlias(table)
+	return normalizeIdentifierToken(table)
+}
+
+func splitTableAlias(table string) (string, string) {
+	table = strings.TrimSpace(table)
 	fields := strings.Fields(table)
 	if len(fields) >= 3 && strings.EqualFold(fields[1], "as") {
-		table = fields[0]
+		return fields[0], fields[2]
 	} else if len(fields) == 2 && isSimpleIdentifierToken(fields[0]) && isSimpleIdentifierToken(fields[1]) {
-		table = fields[0]
+		return fields[0], fields[1]
 	}
-	table = strings.TrimSpace(table)
-	table = strings.Trim(table, "`\"")
-	return strings.ToLower(table)
+	return table, ""
+}
+
+func normalizeIdentifierToken(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, "`\"")
+	value = strings.ReplaceAll(value, "`", "")
+	value = strings.ReplaceAll(value, `"`, "")
+	return strings.ToLower(value)
 }
 
 func isSimpleIdentifierToken(value string) bool {

--- a/orm/query/policy_test.go
+++ b/orm/query/policy_test.go
@@ -238,3 +238,112 @@ func TestRequiredFilterPolicy(t *testing.T) {
 		t.Fatalf("unexpected required filter warning=%#v", plan.Warnings)
 	}
 }
+
+func TestRegisteredPolicyChecksJoinedTables(t *testing.T) {
+	ResetPolicyRegistry()
+	t.Cleanup(ResetPolicyRegistry)
+	if err := RegisterTablePolicy(TablePolicy{Table: "users", TenantColumn: "tenant_id", TenantMode: PolicyModeBlock}); err != nil {
+		t.Fatalf("RegisterTablePolicy users: %v", err)
+	}
+	if err := RegisterTablePolicy(TablePolicy{Table: "memberships", TenantColumn: "tenant_id", TenantMode: PolicyModeBlock}); err != nil {
+		t.Fatalf("RegisterTablePolicy memberships: %v", err)
+	}
+
+	plan, err := New(&recordingExec{}, "users", ormdriver.MySQLDialect{}).
+		Select("users.id").
+		Join("memberships", "users.id", "=", "memberships.user_id").
+		Where("users.tenant_id", 7).
+		Limit(10).
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if countWarnings(plan.Warnings, WarningTenantFilterMissing) != 1 {
+		t.Fatalf("expected one joined-table tenant warning, got %#v", plan.Warnings)
+	}
+	if !plan.Blocked || plan.RiskLevel != RiskBlocked {
+		t.Fatalf("blocked=%v risk=%s warnings=%#v", plan.Blocked, plan.RiskLevel, plan.Warnings)
+	}
+
+	exec := &recordingExec{}
+	err = New(exec, "users", ormdriver.MySQLDialect{}).
+		Select("users.id").
+		Join("memberships", "users.id", "=", "memberships.user_id").
+		Where("users.tenant_id", 7).
+		Limit(10).
+		GetMaps(&[]map[string]any{})
+	if !errors.Is(err, ErrBlockedOperation) {
+		t.Fatalf("GetMaps error=%v", err)
+	}
+	if exec.calls != 0 {
+		t.Fatalf("blocked joined policy query executed database call count=%d", exec.calls)
+	}
+
+	plan, err = New(&recordingExec{}, "users", ormdriver.MySQLDialect{}).
+		Select("users.id").
+		Join("memberships", "users.id", "=", "memberships.user_id").
+		Where("users.tenant_id", 7).
+		Where("memberships.tenant_id", 7).
+		Limit(10).
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan with all tenant predicates: %v", err)
+	}
+	if warningCodeSet(plan.Warnings)[WarningTenantFilterMissing] {
+		t.Fatalf("unexpected tenant warning=%#v", plan.Warnings)
+	}
+}
+
+func TestRequiredFilterPolicySupportsParentScopes(t *testing.T) {
+	ResetPolicyRegistry()
+	t.Cleanup(ResetPolicyRegistry)
+	if err := RegisterTablePolicy(TablePolicy{
+		Table:                 "filing_cases",
+		TenantColumn:          "tenant_id",
+		TenantMode:            PolicyModeBlock,
+		RequiredFilterColumns: []string{"client_company_id", "workplace_id"},
+		RequiredFilterMode:    PolicyModeBlock,
+	}); err != nil {
+		t.Fatalf("RegisterTablePolicy: %v", err)
+	}
+
+	plan, err := New(&recordingExec{}, "filing_cases", ormdriver.MySQLDialect{}).
+		Select("id").
+		Where("tenant_id", 7).
+		Where("client_company_id", 11).
+		Limit(10).
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if countWarnings(plan.Warnings, WarningRequiredFilterMissing) != 1 {
+		t.Fatalf("expected missing workplace required filter, got %#v", plan.Warnings)
+	}
+	if !plan.Blocked {
+		t.Fatalf("missing required parent scope should block, warnings=%#v", plan.Warnings)
+	}
+
+	plan, err = New(&recordingExec{}, "filing_cases", ormdriver.MySQLDialect{}).
+		Select("id").
+		Where("tenant_id", 7).
+		Where("client_company_id", 11).
+		Where("workplace_id", 13).
+		Limit(10).
+		Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan with parent scopes: %v", err)
+	}
+	if warningCodeSet(plan.Warnings)[WarningRequiredFilterMissing] {
+		t.Fatalf("unexpected required filter warning=%#v", plan.Warnings)
+	}
+}
+
+func countWarnings(warnings []Warning, code string) int {
+	count := 0
+	for _, warning := range warnings {
+		if warning.Code == code {
+			count++
+		}
+	}
+	return count
+}

--- a/orm/query/query.go
+++ b/orm/query/query.go
@@ -41,6 +41,7 @@ type Query struct {
 	ctx           context.Context
 	err           error
 	dialect       driver.Dialect
+	paramSeq      int
 	primaryKey    string
 	approval      *Approval
 	suppressions  []Suppression
@@ -55,6 +56,7 @@ type Query struct {
 type CursorColumn struct {
 	Name      string
 	Direction string
+	Raw       bool
 }
 
 // CursorAsc returns an ascending keyset cursor column.
@@ -66,6 +68,24 @@ func CursorAsc(name string) CursorColumn {
 func CursorDesc(name string) CursorColumn {
 	return CursorColumn{Name: name, Direction: "desc"}
 }
+
+// CursorAscExpr returns an ascending trusted SQL expression for keyset cursor
+// predicates.
+func CursorAscExpr(expr string) CursorColumn {
+	return CursorColumn{Name: expr, Direction: "asc", Raw: true}
+}
+
+// CursorDescExpr returns a descending trusted SQL expression for keyset cursor
+// predicates.
+func CursorDescExpr(expr string) CursorColumn {
+	return CursorColumn{Name: expr, Direction: "desc", Raw: true}
+}
+
+// CursorAscAlias returns an ascending selected alias cursor column.
+func CursorAscAlias(alias string) CursorColumn { return CursorAsc(alias) }
+
+// CursorDescAlias returns a descending selected alias cursor column.
+func CursorDescAlias(alias string) CursorColumn { return CursorDesc(alias) }
 
 // New creates a Query with given db and table.
 func New(exec executor, table string, dialect driver.Dialect) *Query {
@@ -246,6 +266,11 @@ func (q *Query) queryRow(sqlStr string, args ...any) *sql.Row {
 	return q.exec.QueryRow(sqlStr, args...)
 }
 
+func (q *Query) nextParamName(prefix string) string {
+	q.paramSeq++
+	return fmt.Sprintf("__goquent_%s_%d", prefix, q.paramSeq)
+}
+
 // execStmt executes Exec or ExecContext depending on ctx.
 func (q *Query) execStmt(sqlStr string, args ...any) (sql.Result, error) {
 	if q.ctx != nil {
@@ -329,14 +354,21 @@ func (q *Query) cursorPredicate(columns []CursorColumn, values []any, after bool
 		for j := 0; j < i; j++ {
 			name := fmt.Sprintf("__goquent_cursor_%d_%d", i, j)
 			vals[name] = values[j]
-			comparisons = append(comparisons, fmt.Sprintf("%s = :%s", quoteIdentifierPath(q.dialect, columns[j].Name), name))
+			comparisons = append(comparisons, fmt.Sprintf("%s = :%s", q.cursorColumnSQL(columns[j]), name))
 		}
 		name := fmt.Sprintf("__goquent_cursor_%d_%d", i, i)
 		vals[name] = values[i]
-		comparisons = append(comparisons, fmt.Sprintf("%s %s :%s", quoteIdentifierPath(q.dialect, columns[i].Name), cursorComparisonOperator(columns[i].Direction, after), name))
+		comparisons = append(comparisons, fmt.Sprintf("%s %s :%s", q.cursorColumnSQL(columns[i]), cursorComparisonOperator(columns[i].Direction, after), name))
 		parts = append(parts, "("+strings.Join(comparisons, " AND ")+")")
 	}
 	return "(" + strings.Join(parts, " OR ") + ")", vals
+}
+
+func (q *Query) cursorColumnSQL(column CursorColumn) string {
+	if column.Raw {
+		return column.Name
+	}
+	return quoteIdentifierPath(q.dialect, column.Name)
 }
 
 // First scans the first result into dest struct.
@@ -765,6 +797,72 @@ func (q *Query) WhereRawNoArgs(raw string) *Query {
 	return q.WhereRaw(raw, map[string]any{})
 }
 
+// WhereJSONText adds a PostgreSQL JSONB text equality predicate:
+// column ->> key = value.
+func (q *Query) WhereJSONText(column, key string, value any) *Query {
+	if q.err != nil {
+		return q
+	}
+	if _, ok := q.dialect.(driver.PostgresDialect); !ok {
+		q.err = fmt.Errorf("goquent: JSONB predicates are only supported on PostgreSQL")
+		return q
+	}
+	column = strings.TrimSpace(column)
+	if column == "" {
+		q.err = fmt.Errorf("goquent: JSONB column is required")
+		return q
+	}
+	if key == "" {
+		q.err = fmt.Errorf("goquent: JSONB key is required")
+		return q
+	}
+	columnSQL := quoteIdentifierPath(q.dialect, column)
+	keyName := q.nextParamName("json_key")
+	valueName := q.nextParamName("json_value")
+	return q.WhereRaw(
+		fmt.Sprintf("%s ->> :%s = :%s", columnSQL, keyName, valueName),
+		map[string]any{keyName: key, valueName: value},
+	)
+}
+
+// WhereJSONHasKey adds a PostgreSQL JSONB key-existence predicate:
+// column ? key.
+func (q *Query) WhereJSONHasKey(column, key string) *Query {
+	return q.whereJSONHasKey(column, key, false)
+}
+
+// WhereJSONNotHasKey adds a negated PostgreSQL JSONB key-existence predicate:
+// NOT (column ? key).
+func (q *Query) WhereJSONNotHasKey(column, key string) *Query {
+	return q.whereJSONHasKey(column, key, true)
+}
+
+func (q *Query) whereJSONHasKey(column, key string, negated bool) *Query {
+	if q.err != nil {
+		return q
+	}
+	if _, ok := q.dialect.(driver.PostgresDialect); !ok {
+		q.err = fmt.Errorf("goquent: JSONB predicates are only supported on PostgreSQL")
+		return q
+	}
+	column = strings.TrimSpace(column)
+	if column == "" {
+		q.err = fmt.Errorf("goquent: JSONB column is required")
+		return q
+	}
+	if key == "" {
+		q.err = fmt.Errorf("goquent: JSONB key is required")
+		return q
+	}
+	columnSQL := quoteIdentifierPath(q.dialect, column)
+	keyName := q.nextParamName("json_key")
+	raw := fmt.Sprintf("%s ? :%s", columnSQL, keyName)
+	if negated {
+		raw = "NOT (" + raw + ")"
+	}
+	return q.WhereRaw(raw, map[string]any{keyName: key})
+}
+
 // OrWhereRaw appends raw OR WHERE condition.
 func (q *Query) OrWhereRaw(raw string, vals map[string]any) *Query {
 	if q.err != nil {
@@ -815,9 +913,10 @@ func (q *Query) WhereGroup(fn func(g *Query)) *Query {
 		return q
 	}
 	q.builder.WhereGroup(func(b *qbapi.WhereSelectQueryBuilder) {
-		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx, dialect: q.dialect, paramSeq: q.paramSeq}
 		_ = setFieldValue(reflect.ValueOf(&grp.builder.WhereQueryBuilder), "builder", reflect.ValueOf(b.GetBuilder()))
 		fn(grp)
+		q.paramSeq = grp.paramSeq
 		if grp.err != nil {
 			q.err = grp.err
 		}
@@ -831,9 +930,10 @@ func (q *Query) OrWhereGroup(fn func(g *Query)) *Query {
 		return q
 	}
 	q.builder.OrWhereGroup(func(b *qbapi.WhereSelectQueryBuilder) {
-		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx, dialect: q.dialect, paramSeq: q.paramSeq}
 		_ = setFieldValue(reflect.ValueOf(&grp.builder.WhereQueryBuilder), "builder", reflect.ValueOf(b.GetBuilder()))
 		fn(grp)
+		q.paramSeq = grp.paramSeq
 		if grp.err != nil {
 			q.err = grp.err
 		}
@@ -847,9 +947,10 @@ func (q *Query) WhereNot(fn func(g *Query)) *Query {
 		return q
 	}
 	q.builder.WhereNot(func(b *qbapi.WhereSelectQueryBuilder) {
-		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx, dialect: q.dialect, paramSeq: q.paramSeq}
 		_ = setFieldValue(reflect.ValueOf(&grp.builder.WhereQueryBuilder), "builder", reflect.ValueOf(b.GetBuilder()))
 		fn(grp)
+		q.paramSeq = grp.paramSeq
 		if grp.err != nil {
 			q.err = grp.err
 		}
@@ -863,9 +964,10 @@ func (q *Query) OrWhereNot(fn func(g *Query)) *Query {
 		return q
 	}
 	q.builder.OrWhereNot(func(b *qbapi.WhereSelectQueryBuilder) {
-		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx}
+		grp := &Query{builder: q.builder, exec: q.exec, ctx: q.ctx, dialect: q.dialect, paramSeq: q.paramSeq}
 		_ = setFieldValue(reflect.ValueOf(&grp.builder.WhereQueryBuilder), "builder", reflect.ValueOf(b.GetBuilder()))
 		fn(grp)
+		q.paramSeq = grp.paramSeq
 		if grp.err != nil {
 			q.err = grp.err
 		}
@@ -1912,11 +2014,17 @@ func validateCursorColumns(columns []CursorColumn, values []any) ([]CursorColumn
 		if name == "" {
 			return nil, fmt.Errorf("goquent: cursor column name is required")
 		}
-		if strings.Contains(name, "*") {
-			return nil, fmt.Errorf("goquent: cursor column %q cannot be a wildcard", col.Name)
-		}
-		if err := validateSelectColumn(name); err != nil {
-			return nil, fmt.Errorf("goquent: invalid cursor column %q: %w", col.Name, err)
+		if col.Raw {
+			if err := validateRawSQLFragment(name); err != nil {
+				return nil, fmt.Errorf("goquent: invalid cursor expression %q: %w", col.Name, err)
+			}
+		} else {
+			if strings.Contains(name, "*") {
+				return nil, fmt.Errorf("goquent: cursor column %q cannot be a wildcard", col.Name)
+			}
+			if err := validateSelectColumn(name); err != nil {
+				return nil, fmt.Errorf("goquent: invalid cursor column %q: %w", col.Name, err)
+			}
 		}
 		dir, err := validateOrderDirection(col.Direction)
 		if err != nil {
@@ -1925,7 +2033,7 @@ func validateCursorColumns(columns []CursorColumn, values []any) ([]CursorColumn
 		if values[i] == nil {
 			return nil, fmt.Errorf("goquent: cursor value for %s is nil", name)
 		}
-		normalized[i] = CursorColumn{Name: name, Direction: dir}
+		normalized[i] = CursorColumn{Name: name, Direction: dir, Raw: col.Raw}
 	}
 	return normalized, nil
 }

--- a/orm/query/risk.go
+++ b/orm/query/risk.go
@@ -183,7 +183,7 @@ func finalizePlan(plan *QueryPlan, approval *Approval, suppressions []Suppressio
 	}
 	result := DefaultRiskEngine.CheckQuery(plan)
 	allWarnings := append([]Warning(nil), result.Warnings...)
-	allWarnings = append(allWarnings, checkPolicy(plan, nil)...)
+	allWarnings = append(allWarnings, checkPolicies(plan, nil)...)
 	warnings, suppressed, suppressionWarnings := applySuppressions(allWarnings, suppressions, time.Now().UTC())
 	warnings = append(warnings, suppressionWarnings...)
 
@@ -209,7 +209,7 @@ func finalizePlanWithPolicy(plan *QueryPlan, approval *Approval, suppressions []
 	}
 	result := DefaultRiskEngine.CheckQuery(plan)
 	allWarnings := append([]Warning(nil), result.Warnings...)
-	allWarnings = append(allWarnings, checkPolicy(plan, policy)...)
+	allWarnings = append(allWarnings, checkPolicies(plan, policy)...)
 	warnings, suppressed, suppressionWarnings := applySuppressions(allWarnings, suppressions, time.Now().UTC())
 	warnings = append(warnings, suppressionWarnings...)
 

--- a/orm/query/risk.go
+++ b/orm/query/risk.go
@@ -347,14 +347,75 @@ func hasNoPredicate(plan *QueryPlan) bool {
 }
 
 func hasPrimaryKeyLikePredicate(plan *QueryPlan) bool {
+	if hasMetadataNarrowPredicate(plan) {
+		return true
+	}
 	for _, predicate := range plan.Predicates {
 		col := strings.ToLower(strings.TrimSpace(predicate.Column))
 		col = strings.Trim(col, "`\"")
-		if col == "id" || strings.HasSuffix(col, ".id") || strings.HasSuffix(col, "_id") {
+		if col == "id" || strings.HasSuffix(col, ".id") {
 			return true
 		}
 	}
 	return false
+}
+
+func hasMetadataNarrowPredicate(plan *QueryPlan) bool {
+	if plan == nil || plan.Metadata == nil {
+		return false
+	}
+	metadata, ok := plan.Metadata[MetadataTableRisk].([]TableRiskMetadata)
+	if !ok || len(metadata) == 0 {
+		return false
+	}
+	predicateCols := predicateColumnSet(plan)
+	for _, table := range metadata {
+		if hasAllPredicateColumns(predicateCols, table.PrimaryKeyColumns) {
+			return true
+		}
+		for _, indexCols := range table.UniqueIndexes {
+			if hasAllPredicateColumns(predicateCols, indexCols) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func predicateColumnSet(plan *QueryPlan) map[string]struct{} {
+	out := make(map[string]struct{}, len(plan.Predicates)*2)
+	for _, predicate := range plan.Predicates {
+		addPredicateColumn(out, predicate.Column)
+		addPredicateColumn(out, predicate.ValueColumn)
+	}
+	return out
+}
+
+func addPredicateColumn(out map[string]struct{}, column string) {
+	column = normalizeColumnName(column)
+	if column == "" {
+		return
+	}
+	out[column] = struct{}{}
+	if _, name := splitColumnReference(column); name != "" {
+		out[name] = struct{}{}
+	}
+}
+
+func hasAllPredicateColumns(predicateCols map[string]struct{}, keyCols []string) bool {
+	if len(keyCols) == 0 {
+		return false
+	}
+	for _, col := range keyCols {
+		col = normalizeColumnName(col)
+		if col == "" {
+			return false
+		}
+		if _, ok := predicateCols[col]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func hasWeakPredicate(plan *QueryPlan) bool {

--- a/orm/query/risk_test.go
+++ b/orm/query/risk_test.go
@@ -59,6 +59,44 @@ func TestRiskEngineBlocksUpdateAndDeleteWithoutWhere(t *testing.T) {
 	}
 }
 
+func TestRiskEngineDoesNotTreatForeignIDAsPrimaryKey(t *testing.T) {
+	plan := &QueryPlan{
+		Operation: OperationUpdate,
+		SQL:       "UPDATE users SET name = ? WHERE tenant_id = ?",
+		Tables:    []TableRef{{Name: "users"}},
+		Predicates: []PredicateRef{{
+			Column:   "tenant_id",
+			Operator: "=",
+		}},
+	}
+	result := DefaultRiskEngine.CheckQuery(plan)
+	if !warningCodeSet(result.Warnings)[WarningBulkUpdateDetected] {
+		t.Fatalf("expected tenant_id-only update to remain bulk, got %#v", result.Warnings)
+	}
+}
+
+func TestRiskEngineUsesTableRiskMetadataForCompositeUniqueKeys(t *testing.T) {
+	plan := &QueryPlan{
+		Operation: OperationUpdate,
+		SQL:       "UPDATE users SET name = ? WHERE tenant_id = ? AND external_id = ?",
+		Tables:    []TableRef{{Name: "users"}},
+		Predicates: []PredicateRef{
+			{Column: "tenant_id", Operator: "="},
+			{Column: "external_id", Operator: "="},
+		},
+	}
+	AttachTableRiskMetadata(plan, []TableRiskMetadata{{
+		Table:         "users",
+		UniqueIndexes: [][]string{{"tenant_id", "external_id"}},
+		TenantColumn:  "tenant_id",
+	}})
+
+	result := DefaultRiskEngine.CheckQuery(plan)
+	if warningCodeSet(result.Warnings)[WarningBulkUpdateDetected] {
+		t.Fatalf("expected composite unique predicate to be narrow, got %#v", result.Warnings)
+	}
+}
+
 func TestApprovalRequiredAndProvided(t *testing.T) {
 	exec := &recordingExec{}
 	_, err := newPlanTestQuery(exec).

--- a/orm/review/config.go
+++ b/orm/review/config.go
@@ -1,0 +1,135 @@
+package review
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/faciam-dev/goquent/orm/query"
+)
+
+// Config is the JSON configuration accepted by goquent review --config.
+type Config struct {
+	Manifest             string                          `json:"manifest,omitempty"`
+	Schema               string                          `json:"schema,omitempty"`
+	Policy               string                          `json:"policy,omitempty"`
+	DatabaseSchema       string                          `json:"database_schema,omitempty"`
+	Code                 []string                        `json:"code,omitempty"`
+	RequireFreshManifest bool                            `json:"require_fresh_manifest,omitempty"`
+	FailOn               string                          `json:"fail_on,omitempty"`
+	FailOnPrecision      string                          `json:"fail_on_precision,omitempty"`
+	ShowSuppressed       bool                            `json:"show_suppressed,omitempty"`
+	Rules                map[string]query.RiskRuleConfig `json:"rules,omitempty"`
+	Suppressions         []ConfigSuppression             `json:"suppressions,omitempty"`
+}
+
+// ConfigSuppression suppresses a finding for paths matched by Path.
+type ConfigSuppression struct {
+	Code    string `json:"code"`
+	Path    string `json:"path,omitempty"`
+	Reason  string `json:"reason"`
+	Owner   string `json:"owner,omitempty"`
+	Expires string `json:"expires,omitempty"`
+}
+
+// LoadConfig reads a JSON review config file.
+func LoadConfig(path string) (Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	var cfg Config
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func applyReviewRules(findings []Finding, rules map[string]query.RiskRuleConfig) []Finding {
+	if len(findings) == 0 || len(rules) == 0 {
+		return findings
+	}
+	out := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		rule, ok := rules[finding.Code]
+		if !ok {
+			out = append(out, finding)
+			continue
+		}
+		if rule.Enabled != nil && !*rule.Enabled {
+			continue
+		}
+		if rule.Severity != nil {
+			finding.Level = *rule.Severity
+		}
+		out = append(out, finding)
+	}
+	return out
+}
+
+func configSuppressionsForFile(path string, configs []ConfigSuppression) ([]query.Suppression, error) {
+	var suppressions []query.Suppression
+	for _, cfg := range configs {
+		if !configSuppressionMatchesPath(path, cfg.Path) {
+			continue
+		}
+		suppression := query.Suppression{
+			Code:   strings.TrimSpace(cfg.Code),
+			Reason: strings.TrimSpace(cfg.Reason),
+			Scope:  query.SuppressionScopeConfig,
+			Owner:  strings.TrimSpace(cfg.Owner),
+		}
+		if suppression.Code == "" {
+			return nil, fmt.Errorf("goquent: config suppression code is required")
+		}
+		if suppression.Reason == "" {
+			return nil, fmt.Errorf("goquent: config suppression reason is required")
+		}
+		if strings.TrimSpace(cfg.Expires) != "" {
+			expiresAt, err := parseReviewTime(cfg.Expires)
+			if err != nil {
+				return nil, err
+			}
+			suppression.ExpiresAt = &expiresAt
+		}
+		suppressions = append(suppressions, suppression)
+	}
+	return suppressions, nil
+}
+
+func configSuppressionMatchesPath(path, pattern string) bool {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	if pattern == "" {
+		return true
+	}
+	path = filepath.ToSlash(path)
+	if filepath.IsAbs(path) {
+		if rel, err := filepath.Rel(".", path); err == nil && !strings.HasPrefix(rel, "..") {
+			path = filepath.ToSlash(rel)
+		}
+	}
+	if path == pattern || strings.HasSuffix(path, "/"+pattern) {
+		return true
+	}
+	if strings.HasSuffix(pattern, "/...") {
+		prefix := strings.TrimSuffix(pattern, "/...")
+		return path == prefix || strings.HasPrefix(path, prefix+"/") || strings.HasSuffix(path, "/"+prefix) || strings.Contains(path, "/"+prefix+"/")
+	}
+	if strings.HasSuffix(pattern, "/") {
+		return strings.HasPrefix(path, pattern) || strings.Contains(path, "/"+pattern)
+	}
+	return false
+}
+
+func parseReviewTime(value string) (time.Time, error) {
+	if t, err := time.Parse("2006-01-02", value); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("goquent: invalid config suppression expires %q", value)
+}

--- a/orm/review/context.go
+++ b/orm/review/context.go
@@ -1,0 +1,111 @@
+package review
+
+import (
+	"strings"
+
+	"github.com/faciam-dev/goquent/orm/manifest"
+	"github.com/faciam-dev/goquent/orm/query"
+)
+
+type reviewContext struct {
+	manifest             *manifest.Manifest
+	riskMetadata         []query.TableRiskMetadata
+	tables               map[string]manifest.Table
+	rules                map[string]query.RiskRuleConfig
+	configSuppressions   []ConfigSuppression
+	registeredSoftDelete map[string]string
+}
+
+func newReviewContext(opts Options) reviewContext {
+	m := opts.CurrentManifest
+	if m == nil && strings.TrimSpace(opts.ManifestPath) != "" {
+		loaded, err := manifest.Load(opts.ManifestPath)
+		if err == nil {
+			m = loaded
+		}
+	}
+	ctx := reviewContext{
+		manifest:           m,
+		rules:              opts.Rules,
+		configSuppressions: append([]ConfigSuppression(nil), opts.ConfigSuppressions...),
+	}
+	if m == nil {
+		return ctx
+	}
+	ctx.tables = make(map[string]manifest.Table, len(m.Tables))
+	for _, table := range m.Tables {
+		ctx.tables[normalizeReviewName(table.Name)] = table
+	}
+	ctx.riskMetadata = tableRiskMetadataFromManifest(m)
+	return ctx
+}
+
+func tableRiskMetadataFromManifest(m *manifest.Manifest) []query.TableRiskMetadata {
+	if m == nil {
+		return nil
+	}
+	out := make([]query.TableRiskMetadata, 0, len(m.Tables))
+	for _, table := range m.Tables {
+		meta := query.TableRiskMetadata{Table: table.Name}
+		for _, column := range table.Columns {
+			if column.Primary {
+				meta.PrimaryKeyColumns = append(meta.PrimaryKeyColumns, column.Name)
+			}
+		}
+		for _, index := range table.Indexes {
+			if index.Unique && len(index.Columns) > 0 {
+				meta.UniqueIndexes = append(meta.UniqueIndexes, append([]string(nil), index.Columns...))
+			}
+		}
+		for _, policy := range table.Policies {
+			switch policy.Type {
+			case "tenant_scope":
+				meta.TenantColumn = policy.Column
+			case "soft_delete":
+				meta.SoftDeleteColumn = policy.Column
+			case "required_filter":
+				meta.RequiredFilterColumns = append(meta.RequiredFilterColumns, policy.Column)
+			}
+		}
+		for _, column := range table.Columns {
+			if column.TenantScope && meta.TenantColumn == "" {
+				meta.TenantColumn = column.Name
+			}
+			if column.SoftDelete && meta.SoftDeleteColumn == "" {
+				meta.SoftDeleteColumn = column.Name
+			}
+			if column.RequiredFilter && !containsReviewColumn(meta.RequiredFilterColumns, column.Name) {
+				meta.RequiredFilterColumns = append(meta.RequiredFilterColumns, column.Name)
+			}
+		}
+		out = append(out, meta)
+	}
+	return out
+}
+
+func (ctx reviewContext) table(name string) (manifest.Table, bool) {
+	if ctx.tables == nil {
+		return manifest.Table{}, false
+	}
+	table, ok := ctx.tables[normalizeReviewName(name)]
+	return table, ok
+}
+
+func normalizeReviewName(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "`\"")
+	if idx := strings.LastIndex(s, "."); idx >= 0 {
+		s = s[idx+1:]
+	}
+	return strings.ToLower(s)
+}
+
+func containsReviewColumn(cols []string, col string) bool {
+	target := normalizeReviewName(col)
+	for _, existing := range cols {
+		if normalizeReviewName(existing) == target {
+			return true
+		}
+	}
+	return false
+}

--- a/orm/review/go.go
+++ b/orm/review/go.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/faciam-dev/goquent/orm/manifest"
 	"github.com/faciam-dev/goquent/orm/query"
 )
 
@@ -15,12 +16,14 @@ type chainCall struct {
 	Call   *ast.CallExpr
 }
 
-func reviewGoFile(path string) ([]Finding, error) {
+func reviewGoFile(ctx reviewContext, path string) ([]Finding, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}
+	fileCtx := ctx
+	fileCtx.registeredSoftDelete = staticSoftDeleteRegistrations(file)
 
 	var findings []Finding
 	ast.Inspect(file, func(n ast.Node) bool {
@@ -38,7 +41,7 @@ func reviewGoFile(path string) ([]Finding, error) {
 			findings = append(findings, reviewRawSQLCall(sel, call, loc)...)
 		}
 		if isGoquentTerminal(sel.Sel.Name) {
-			findings = append(findings, reviewGoquentChain(sel, call, loc)...)
+			findings = append(findings, reviewGoquentChain(fileCtx, sel, call, loc)...)
 		}
 		if isRawBuilderMethod(sel.Sel.Name) {
 			findings = append(findings, reviewRawBuilderCall(sel, call, loc)...)
@@ -46,7 +49,37 @@ func reviewGoFile(path string) ([]Finding, error) {
 		return true
 	})
 
-	return applyFileSuppressions(path, findings)
+	return applyFileSuppressions(ctx, path, findings)
+}
+
+func staticSoftDeleteRegistrations(file *ast.File) map[string]string {
+	out := map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Register" {
+			return true
+		}
+		calls, _, _ := collectChainCalls(call)
+		table, ok := tableFromChain(calls)
+		if !ok {
+			return true
+		}
+		for _, chainCall := range calls {
+			if chainCall.Method != "SoftDelete" || chainCall.Call == nil || len(chainCall.Call.Args) == 0 {
+				continue
+			}
+			column, ok := stringLiteralValue(chainCall.Call.Args[0])
+			if ok && strings.TrimSpace(column) != "" {
+				out[normalizeReviewName(table)] = column
+			}
+		}
+		return true
+	})
+	return out
 }
 
 func reviewRawSQLCall(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.SourceLocation) []Finding {
@@ -74,7 +107,7 @@ func reviewRawSQLCall(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.Sour
 	return findingsFromPlan(query.NewRawPlan(sqlText), query.AnalysisPrecise, loc)
 }
 
-func reviewGoquentChain(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.SourceLocation) []Finding {
+func reviewGoquentChain(ctx reviewContext, sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.SourceLocation) []Finding {
 	calls, root, _ := collectChainCalls(call)
 	if !chainHasRootBuilder(calls) {
 		if receiverLooksQuery(sel.X) || receiverLooksQuery(root) {
@@ -84,6 +117,13 @@ func reviewGoquentChain(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.So
 	}
 
 	method := sel.Sel.Name
+	if plan, ok := staticPlanFromChain(ctx, method, calls); ok {
+		result := query.DefaultRiskEngine.CheckQuery(plan)
+		findings := warningsToFindings(result.Warnings, query.AnalysisPrecise, loc)
+		findings = append(findings, manifestPolicyFindings(ctx, plan, loc)...)
+		return findings
+	}
+
 	var findings []Finding
 	switch method {
 	case "Update", "PlanUpdate":
@@ -149,6 +189,474 @@ func reviewGoquentChain(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.So
 		}
 	}
 	return findings
+}
+
+func staticPlanFromChain(ctx reviewContext, method string, calls []chainCall) (*query.QueryPlan, bool) {
+	op, ok := operationForTerminal(method)
+	if !ok {
+		return nil, false
+	}
+	table, ok := tableFromChain(calls)
+	if !ok {
+		return nil, false
+	}
+	plan := &query.QueryPlan{
+		Operation:         op,
+		SQL:               staticSQLShape(op, table, calls),
+		Tables:            []query.TableRef{{Name: table}},
+		Predicates:        predicatesFromChain(calls),
+		RiskLevel:         query.RiskLow,
+		AnalysisPrecision: query.AnalysisPrecise,
+	}
+	if op == query.OperationSelect {
+		plan.Columns = selectedColumnsFromChain(calls)
+		if len(plan.Columns) == 0 {
+			plan.Columns = []query.ColumnRef{{Name: "*"}}
+		}
+	}
+	if limit, ok := limitFromChain(calls); ok {
+		plan.Limit = &limit
+	}
+	for _, joinTable := range joinedTablesFromChain(calls) {
+		plan.Tables = append(plan.Tables, query.TableRef{Name: joinTable})
+	}
+	if hasChainMethod(calls, "WithDeleted") || hasChainMethod(calls, "OnlyDeleted") {
+		plan.Metadata = map[string]any{"soft_delete": "with_deleted"}
+	}
+	if len(ctx.riskMetadata) > 0 {
+		query.AttachTableRiskMetadata(plan, ctx.riskMetadata)
+	}
+	return plan, true
+}
+
+func operationForTerminal(method string) (query.OperationType, bool) {
+	switch method {
+	case "Update", "PlanUpdate":
+		return query.OperationUpdate, true
+	case "Delete", "PlanDelete":
+		return query.OperationDelete, true
+	case "Get", "GetMaps", "First", "FirstMap", "Plan":
+		return query.OperationSelect, true
+	default:
+		return "", false
+	}
+}
+
+func tableFromChain(calls []chainCall) (string, bool) {
+	for _, call := range calls {
+		switch call.Method {
+		case "Table":
+			if call.Call == nil || len(call.Call.Args) == 0 {
+				return "", false
+			}
+			table, ok := stringLiteralValue(call.Call.Args[0])
+			return table, ok && strings.TrimSpace(table) != ""
+		case "TablePath":
+			if call.Call == nil || len(call.Call.Args) == 0 {
+				return "", false
+			}
+			parts := make([]string, 0, len(call.Call.Args))
+			for _, arg := range call.Call.Args {
+				part, ok := stringLiteralValue(arg)
+				if !ok || strings.TrimSpace(part) == "" {
+					return "", false
+				}
+				parts = append(parts, part)
+			}
+			return strings.Join(parts, "."), true
+		}
+	}
+	return "", false
+}
+
+func staticSQLShape(op query.OperationType, table string, calls []chainCall) string {
+	hasWhere := len(predicatesFromChain(calls)) > 0
+	switch op {
+	case query.OperationUpdate:
+		if hasWhere {
+			return "UPDATE " + table + " SET ..."
+		}
+		return "UPDATE " + table + " SET ..."
+	case query.OperationDelete:
+		if hasWhere {
+			return "DELETE FROM " + table + " WHERE ..."
+		}
+		return "DELETE FROM " + table
+	default:
+		return "SELECT ... FROM " + table
+	}
+}
+
+func selectedColumnsFromChain(calls []chainCall) []query.ColumnRef {
+	var columns []query.ColumnRef
+	for _, call := range calls {
+		if call.Call == nil {
+			continue
+		}
+		switch call.Method {
+		case "Select":
+			for _, arg := range call.Call.Args {
+				col, ok := stringLiteralValue(arg)
+				if !ok {
+					continue
+				}
+				columns = append(columns, query.ColumnRef{Name: col})
+			}
+		case "SelectRaw":
+			if len(call.Call.Args) > 0 {
+				raw, ok := stringLiteralValue(call.Call.Args[0])
+				if ok {
+					columns = append(columns, query.ColumnRef{Expression: raw, Raw: true})
+				}
+			}
+		case "Distinct", "Count", "Max", "Min", "Sum", "Avg":
+			name := ""
+			if len(call.Call.Args) > 0 {
+				name, _ = stringLiteralValue(call.Call.Args[0])
+			}
+			columns = append(columns, query.ColumnRef{Name: name, Function: call.Method, Count: call.Method == "Count"})
+		}
+	}
+	return columns
+}
+
+func predicatesFromChain(calls []chainCall) []query.PredicateRef {
+	var predicates []query.PredicateRef
+	for _, call := range calls {
+		if call.Call == nil || !isPredicateMethod(call.Method) {
+			continue
+		}
+		p := query.PredicateRef{Connector: "AND"}
+		if strings.HasPrefix(call.Method, "Or") {
+			p.Connector = "OR"
+		}
+		if strings.Contains(call.Method, "Raw") {
+			predicates = append(predicates, p)
+			continue
+		}
+		if len(call.Call.Args) > 0 {
+			p.Column, _ = stringLiteralValue(call.Call.Args[0])
+		}
+		switch call.Method {
+		case "WhereNull":
+			p.Operator = "IS NULL"
+		case "WhereNotNull":
+			p.Operator = "IS NOT NULL"
+		default:
+			if len(call.Call.Args) > 2 {
+				p.Operator, _ = stringLiteralValue(call.Call.Args[1])
+				p.ValueCount = 1
+			} else if len(call.Call.Args) > 1 {
+				p.Operator = "="
+				p.ValueCount = 1
+			}
+		}
+		predicates = append(predicates, p)
+	}
+	return predicates
+}
+
+func limitFromChain(calls []chainCall) (int64, bool) {
+	for _, call := range calls {
+		switch call.Method {
+		case "Limit", "Take":
+			return 1, true
+		}
+	}
+	return 0, false
+}
+
+func joinedTablesFromChain(calls []chainCall) []string {
+	var tables []string
+	for _, call := range calls {
+		if call.Call == nil || len(call.Call.Args) == 0 {
+			continue
+		}
+		switch call.Method {
+		case "Join", "LeftJoin", "RightJoin", "CrossJoin":
+			table, ok := stringLiteralValue(call.Call.Args[0])
+			if ok && strings.TrimSpace(table) != "" {
+				tables = append(tables, table)
+			}
+		}
+	}
+	return tables
+}
+
+func hasChainMethod(calls []chainCall, method string) bool {
+	for _, call := range calls {
+		if call.Method == method {
+			return true
+		}
+	}
+	return false
+}
+
+func manifestPolicyFindings(ctx reviewContext, plan *query.QueryPlan, loc *query.SourceLocation) []Finding {
+	if ctx.manifest == nil || plan == nil {
+		return nil
+	}
+	policies := touchedManifestTables(ctx, plan)
+	ambiguous := ambiguousPolicyColumns(policies)
+	var findings []Finding
+	for _, table := range policies {
+		findings = append(findings, manifestPolicyFindingsForTable(ctx, table, plan, loc, ambiguous)...)
+	}
+	return findings
+}
+
+func touchedManifestTables(ctx reviewContext, plan *query.QueryPlan) []manifest.Table {
+	var tables []manifest.Table
+	seen := map[string]struct{}{}
+	for _, ref := range plan.Tables {
+		table, ok := ctx.table(ref.Name)
+		if !ok {
+			continue
+		}
+		key := normalizeReviewName(table.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		tables = append(tables, table)
+	}
+	return tables
+}
+
+func ambiguousPolicyColumns(tables []manifest.Table) map[string]bool {
+	owners := map[string]map[string]struct{}{}
+	add := func(table, col string) {
+		col = normalizeReviewName(col)
+		if col == "" {
+			return
+		}
+		if owners[col] == nil {
+			owners[col] = map[string]struct{}{}
+		}
+		owners[col][normalizeReviewName(table)] = struct{}{}
+	}
+	for _, table := range tables {
+		for _, required := range requiredColumnsForManifestTable(table) {
+			add(table.Name, required.column)
+		}
+		if softDeleteColumnForManifestTable(table) != "" {
+			add(table.Name, softDeleteColumnForManifestTable(table))
+		}
+	}
+	out := map[string]bool{}
+	for col, ownerSet := range owners {
+		if len(ownerSet) > 1 {
+			out[col] = true
+		}
+	}
+	return out
+}
+
+func manifestPolicyFindingsForTable(ctx reviewContext, table manifest.Table, plan *query.QueryPlan, loc *query.SourceLocation, ambiguous map[string]bool) []Finding {
+	if plan.Operation != query.OperationSelect && plan.Operation != query.OperationUpdate && plan.Operation != query.OperationDelete {
+		return nil
+	}
+	var findings []Finding
+	for _, required := range requiredColumnsForManifestTable(table) {
+		allowUnqualified := !ambiguous[normalizeReviewName(required.column)]
+		if planHasPredicateForTable(plan, table.Name, required.column, allowUnqualified) {
+			continue
+		}
+		code := query.WarningRequiredFilterMissing
+		message := table.Name + " requires a filter on " + required.column
+		if required.policyType == "tenant_scope" {
+			code = query.WarningTenantFilterMissing
+			message = table.Name + " is tenant-scoped but " + required.column + " filter is missing"
+		}
+		findings = append(findings, staticFinding(
+			code,
+			policyModeLevel(required.mode, query.RiskHigh),
+			message,
+			"add the required filter before executing this query",
+			loc,
+			query.AnalysisPrecise,
+		))
+	}
+	if softDelete := softDeleteColumnForManifestTable(table); softDelete != "" && !staticPlanWithDeleted(plan) && !ctx.hasRegisteredSoftDelete(table.Name, softDelete) {
+		allowUnqualified := !ambiguous[normalizeReviewName(softDelete)]
+		if !planHasPredicateForTable(plan, table.Name, softDelete, allowUnqualified) {
+			findings = append(findings, staticFinding(
+				query.WarningSoftDeleteFilterMissing,
+				policyModeLevel(policyModeForManifestPolicy(table, "soft_delete", softDelete), query.RiskMedium),
+				table.Name+" has soft delete policy but "+softDelete+" filter is missing",
+				"use the default soft delete filter or explicitly call WithDeleted",
+				loc,
+				query.AnalysisPrecise,
+			))
+		}
+	}
+	if plan.Operation == query.OperationSelect {
+		for _, col := range selectedPIIColumnsForManifestTable(table, plan) {
+			findings = append(findings, staticFinding(
+				query.WarningPIIColumnSelected,
+				policyModeLevel(policyModeForManifestPolicy(table, "pii", col), query.RiskMedium),
+				"PII column selected: "+table.Name+"."+col,
+				"avoid selecting PII or include a narrow access reason",
+				loc,
+				query.AnalysisPrecise,
+			))
+		}
+	}
+	return findings
+}
+
+func (ctx reviewContext) hasRegisteredSoftDelete(table, column string) bool {
+	if len(ctx.registeredSoftDelete) == 0 {
+		return false
+	}
+	registered, ok := ctx.registeredSoftDelete[normalizeReviewName(table)]
+	return ok && normalizeReviewName(registered) == normalizeReviewName(column)
+}
+
+type manifestRequiredColumn struct {
+	column     string
+	mode       query.PolicyMode
+	policyType string
+}
+
+func requiredColumnsForManifestTable(table manifest.Table) []manifestRequiredColumn {
+	seen := map[string]manifestRequiredColumn{}
+	for _, column := range table.Columns {
+		if column.TenantScope || column.RequiredFilter {
+			policyType := "required_filter"
+			if column.TenantScope {
+				policyType = "tenant_scope"
+			}
+			seen[normalizeReviewName(column.Name)] = manifestRequiredColumn{column: column.Name, mode: query.PolicyModeEnforce, policyType: policyType}
+		}
+	}
+	for _, policy := range table.Policies {
+		if policy.Type != "tenant_scope" && policy.Type != "required_filter" {
+			continue
+		}
+		mode := policy.Mode
+		if mode == "" {
+			mode = query.PolicyModeEnforce
+		}
+		seen[normalizeReviewName(policy.Column)] = manifestRequiredColumn{column: policy.Column, mode: mode, policyType: policy.Type}
+	}
+	out := make([]manifestRequiredColumn, 0, len(seen))
+	for _, required := range seen {
+		out = append(out, required)
+	}
+	return out
+}
+
+func softDeleteColumnForManifestTable(table manifest.Table) string {
+	for _, policy := range table.Policies {
+		if policy.Type == "soft_delete" && strings.TrimSpace(policy.Column) != "" {
+			return policy.Column
+		}
+	}
+	for _, column := range table.Columns {
+		if column.SoftDelete {
+			return column.Name
+		}
+	}
+	return ""
+}
+
+func policyModeForManifestPolicy(table manifest.Table, policyType, column string) query.PolicyMode {
+	for _, policy := range table.Policies {
+		if policy.Type == policyType && normalizeReviewName(policy.Column) == normalizeReviewName(column) {
+			if policy.Mode != "" {
+				return policy.Mode
+			}
+		}
+	}
+	return query.PolicyModeWarn
+}
+
+func staticPlanWithDeleted(plan *query.QueryPlan) bool {
+	if plan.Metadata == nil {
+		return false
+	}
+	v, _ := plan.Metadata["soft_delete"].(string)
+	return v == "with_deleted"
+}
+
+func selectedPIIColumnsForManifestTable(table manifest.Table, plan *query.QueryPlan) []string {
+	selectedAll := false
+	selected := map[string]struct{}{}
+	for _, column := range plan.Columns {
+		if strings.TrimSpace(column.Name) == "*" || strings.TrimSpace(column.Expression) == "*" {
+			selectedAll = true
+			continue
+		}
+		if column.Name != "" {
+			selected[normalizeReviewName(column.Name)] = struct{}{}
+		}
+	}
+	var out []string
+	for _, column := range table.Columns {
+		if !column.PII {
+			continue
+		}
+		if selectedAll {
+			out = append(out, column.Name)
+			continue
+		}
+		if _, ok := selected[normalizeReviewName(column.Name)]; ok {
+			out = append(out, column.Name)
+		}
+	}
+	return out
+}
+
+func planHasPredicateForTable(plan *query.QueryPlan, table, column string, allowUnqualified bool) bool {
+	target := normalizeReviewName(column)
+	for _, predicate := range plan.Predicates {
+		if reviewColumnMatches(predicate.Column, table, target, allowUnqualified) ||
+			reviewColumnMatches(predicate.ValueColumn, table, target, allowUnqualified) {
+			return true
+		}
+	}
+	return false
+}
+
+func reviewColumnMatches(reference, table, column string, allowUnqualified bool) bool {
+	qualifier, name := splitReviewColumn(reference)
+	if name == "" || name != column {
+		return false
+	}
+	if qualifier == "" {
+		return allowUnqualified
+	}
+	return qualifier == normalizeReviewName(table)
+}
+
+func splitReviewColumn(reference string) (string, string) {
+	reference = strings.TrimSpace(reference)
+	reference = strings.Trim(reference, "`\"")
+	if reference == "" {
+		return "", ""
+	}
+	idx := strings.LastIndex(reference, ".")
+	if idx < 0 {
+		return "", normalizeReviewName(reference)
+	}
+	return normalizeReviewName(reference[:idx]), normalizeReviewName(reference[idx+1:])
+}
+
+func policyModeLevel(mode query.PolicyMode, fallback query.RiskLevel) query.RiskLevel {
+	switch mode {
+	case query.PolicyModeWarn:
+		return fallback
+	case query.PolicyModeEnforce:
+		if compareRisk(fallback, query.RiskHigh) < 0 {
+			return query.RiskHigh
+		}
+		return fallback
+	case query.PolicyModeBlock:
+		return query.RiskBlocked
+	default:
+		return fallback
+	}
 }
 
 func reviewRawBuilderCall(sel *ast.SelectorExpr, call *ast.CallExpr, loc *query.SourceLocation) []Finding {

--- a/orm/review/review.go
+++ b/orm/review/review.go
@@ -38,8 +38,10 @@ type ReviewSummary struct {
 
 // ManifestStatus is reserved for Phase 6 stale manifest integration.
 type ManifestStatus struct {
-	Fresh bool   `json:"fresh"`
-	Path  string `json:"path,omitempty"`
+	Fresh    bool   `json:"fresh"`
+	Verified bool   `json:"verified,omitempty"`
+	State    string `json:"state,omitempty"`
+	Path     string `json:"path,omitempty"`
 }
 
 // ReviewReport is the top-level report produced by goquent review.
@@ -56,6 +58,10 @@ type Options struct {
 	ShowSuppressed       bool
 	ManifestPath         string
 	RequireFreshManifest bool
+	CurrentManifest      *manifest.Manifest
+	ManifestInputs       bool
+	Rules                map[string]query.RiskRuleConfig
+	ConfigSuppressions   []ConfigSuppression
 }
 
 // Run reviews all configured paths.
@@ -64,11 +70,12 @@ func Run(opts Options) (ReviewReport, error) {
 	if len(paths) == 0 {
 		paths = []string{"."}
 	}
+	ctx := newReviewContext(opts)
 
 	var report ReviewReport
 	var errs []error
-	if strings.TrimSpace(opts.ManifestPath) != "" {
-		findings, status, err := reviewManifestFreshness(opts.ManifestPath)
+	if strings.TrimSpace(opts.ManifestPath) != "" || opts.RequireFreshManifest {
+		findings, status, err := reviewManifestFreshness(opts)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -84,7 +91,7 @@ func Run(opts Options) (ReviewReport, error) {
 			continue
 		}
 		for _, file := range files {
-			findings, err := reviewFile(file)
+			findings, err := reviewFile(ctx, file)
 			if err != nil {
 				errs = append(errs, err)
 				continue
@@ -105,33 +112,94 @@ func Run(opts Options) (ReviewReport, error) {
 	return report, errors.Join(errs...)
 }
 
-func reviewManifestFreshness(path string) ([]Finding, *ManifestStatus, error) {
+func reviewManifestFreshness(opts Options) ([]Finding, *ManifestStatus, error) {
+	path := strings.TrimSpace(opts.ManifestPath)
+	if path == "" {
+		if !opts.RequireFreshManifest {
+			return nil, nil, nil
+		}
+		status := &ManifestStatus{Fresh: false, State: "missing"}
+		return []Finding{manifestFinding(
+			manifest.WarningRequired,
+			query.RiskHigh,
+			"fresh manifest is required but no manifest path was provided",
+			"pass --manifest and current schema, policy, code, or database fingerprint inputs",
+			&query.SourceLocation{Line: 1},
+			nil,
+		)}, status, nil
+	}
 	m, err := manifest.Load(path)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if opts.CurrentManifest != nil {
+		verification := manifest.Verify(m, opts.CurrentManifest, time.Time{})
+		status := &ManifestStatus{Fresh: verification.Fresh, Verified: true, Path: path}
+		if verification.Fresh {
+			status.State = "fresh"
+			return nil, status, nil
+		}
+		status.State = "stale"
+		return []Finding{staleManifestFinding(path, verification)}, status, nil
+	}
+
+	if opts.RequireFreshManifest && !opts.ManifestInputs {
+		status := &ManifestStatus{Fresh: false, State: "unverified", Path: path}
+		return []Finding{manifestFinding(
+			manifest.WarningUnverified,
+			query.RiskHigh,
+			"manifest freshness could not be verified against current inputs",
+			"pass --schema, --policy, --code, or --database-schema with --require-fresh-manifest",
+			&query.SourceLocation{File: path, Line: 1},
+			nil,
+		)}, status, nil
+	}
+
 	status := &ManifestStatus{Fresh: true, Path: path}
 	if m.Verification != nil {
 		status.Fresh = m.Verification.Fresh
+		status.Verified = true
 	}
-	if m.Verification == nil || m.Verification.Fresh {
+	if m.Verification == nil {
+		status.State = "unverified"
 		return nil, status, nil
 	}
+	if m.Verification.Fresh {
+		status.State = "fresh"
+		return nil, status, nil
+	}
+	status.State = "stale"
+	return []Finding{staleManifestFinding(path, *m.Verification)}, status, nil
+}
+
+func staleManifestFinding(path string, verification manifest.Verification) Finding {
 	var evidence []query.Evidence
-	for _, check := range m.Verification.Checks {
+	for _, check := range verification.Checks {
 		if check.Status == "stale" {
 			evidence = append(evidence, query.Evidence{Key: check.Name, Value: check.Message})
 		}
 	}
-	return []Finding{{
-		Code:              manifest.WarningStale,
-		Level:             query.RiskHigh,
-		Message:           "manifest does not match current schema, policy, generated code, or database fingerprint",
-		Location:          &query.SourceLocation{File: path, Line: 1},
-		Hint:              "regenerate the manifest or run goquent manifest verify against current inputs",
+	return manifestFinding(
+		manifest.WarningStale,
+		query.RiskHigh,
+		"manifest does not match current schema, policy, generated code, or database fingerprint",
+		"regenerate the manifest or run goquent manifest verify against current inputs",
+		&query.SourceLocation{File: path, Line: 1},
+		evidence,
+	)
+}
+
+func manifestFinding(code string, level query.RiskLevel, message, hint string, loc *query.SourceLocation, evidence []query.Evidence) Finding {
+	return Finding{
+		Code:              code,
+		Level:             level,
+		Message:           message,
+		Location:          loc,
+		Hint:              hint,
 		Evidence:          evidence,
 		AnalysisPrecision: query.AnalysisPrecise,
-	}}, status, nil
+	}
 }
 
 func discoverFiles(root string) ([]string, error) {
@@ -192,20 +260,20 @@ func supportedFile(path string) bool {
 	}
 }
 
-func reviewFile(path string) ([]Finding, error) {
+func reviewFile(ctx reviewContext, path string) ([]Finding, error) {
 	switch filepath.Ext(path) {
 	case ".go":
-		return reviewGoFile(path)
+		return reviewGoFile(ctx, path)
 	case ".sql":
-		return reviewSQLFile(path)
+		return reviewSQLFile(ctx, path)
 	case ".json":
-		return reviewPlanJSONFile(path)
+		return reviewPlanJSONFile(ctx, path)
 	default:
 		return nil, nil
 	}
 }
 
-func reviewSQLFile(path string) ([]Finding, error) {
+func reviewSQLFile(ctx reviewContext, path string) ([]Finding, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -216,12 +284,12 @@ func reviewSQLFile(path string) ([]Finding, error) {
 			return nil, err
 		} else if len(plan.Steps) > 0 {
 			findings := warningsToFindings(plan.Warnings, plan.AnalysisPrecision, &query.SourceLocation{File: path, Line: 1})
-			return applyFileSuppressions(path, findings)
+			return applyFileSuppressions(ctx, path, findings)
 		}
 	}
 	plan := query.NewRawPlan(sqlText)
 	findings := findingsFromPlan(plan, query.AnalysisPrecise, &query.SourceLocation{File: path, Line: 1})
-	return applyFileSuppressions(path, findings)
+	return applyFileSuppressions(ctx, path, findings)
 }
 
 func looksLikeMigrationSQL(sqlText string) bool {
@@ -234,7 +302,7 @@ func looksLikeMigrationSQL(sqlText string) bool {
 	return false
 }
 
-func reviewPlanJSONFile(path string) ([]Finding, error) {
+func reviewPlanJSONFile(ctx reviewContext, path string) ([]Finding, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -246,9 +314,15 @@ func reviewPlanJSONFile(path string) ([]Finding, error) {
 	if plan.Operation == "" || plan.SQL == "" {
 		migrationFindings, ok, err := reviewMigrationPlanJSON(path, b)
 		if err != nil || ok {
-			return migrationFindings, err
+			if err != nil {
+				return nil, err
+			}
+			return applyFileSuppressions(ctx, path, migrationFindings)
 		}
 		return nil, nil
+	}
+	if len(ctx.riskMetadata) > 0 {
+		query.AttachTableRiskMetadata(&plan, ctx.riskMetadata)
 	}
 	result := query.DefaultRiskEngine.CheckQuery(&plan)
 	warnings := plan.Warnings
@@ -260,7 +334,7 @@ func reviewPlanJSONFile(path string) ([]Finding, error) {
 		finding.Suppressed = true
 		findings = append(findings, finding)
 	}
-	return applyFileSuppressions(path, findings)
+	return applyFileSuppressions(ctx, path, findings)
 }
 
 func reviewMigrationPlanJSON(path string, b []byte) ([]Finding, bool, error) {
@@ -280,8 +354,7 @@ func reviewMigrationPlanJSON(path string, b []byte) ([]Finding, bool, error) {
 		plan.AnalysisPrecision = planned.AnalysisPrecision
 	}
 	findings := warningsToFindings(plan.Warnings, plan.AnalysisPrecision, &query.SourceLocation{File: path, Line: 1})
-	findings, err := applyFileSuppressions(path, findings)
-	return findings, true, err
+	return findings, true, nil
 }
 
 func findingsFromPlan(plan *query.QueryPlan, precision query.AnalysisPrecision, loc *query.SourceLocation) []Finding {
@@ -323,7 +396,8 @@ func cloneLocation(loc *query.SourceLocation) *query.SourceLocation {
 	return &copied
 }
 
-func applyFileSuppressions(path string, findings []Finding) ([]Finding, error) {
+func applyFileSuppressions(ctx reviewContext, path string, findings []Finding) ([]Finding, error) {
+	findings = applyReviewRules(findings, ctx.rules)
 	if len(findings) == 0 {
 		return findings, nil
 	}
@@ -331,6 +405,11 @@ func applyFileSuppressions(path string, findings []Finding) ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
+	configSuppressions, err := configSuppressionsForFile(path, ctx.configSuppressions)
+	if err != nil {
+		return nil, err
+	}
+	suppressions = append(suppressions, configSuppressions...)
 	if len(suppressions) == 0 {
 		return findings, nil
 	}
@@ -401,7 +480,7 @@ func findingSuppressible(code string) bool {
 	switch code {
 	case query.WarningUpdateWithoutWhere, query.WarningDeleteWithoutWhere, query.WarningDestructiveSQL,
 		migration.WarningMigrationDropTable, migration.WarningMigrationDropColumn, migration.WarningMigrationTypeNarrowing,
-		manifest.WarningStale:
+		manifest.WarningStale, manifest.WarningUnverified, manifest.WarningRequired:
 		return false
 	default:
 		return true
@@ -450,6 +529,19 @@ func HasFindingsAtOrAbove(report ReviewReport, threshold query.RiskLevel) bool {
 	return false
 }
 
+// HasFindingsAtOrAbovePrecision reports whether findings meet a precision threshold.
+func HasFindingsAtOrAbovePrecision(report ReviewReport, threshold query.AnalysisPrecision) bool {
+	for _, finding := range report.Findings {
+		if finding.Suppressed {
+			continue
+		}
+		if comparePrecision(finding.AnalysisPrecision, threshold) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseRiskLevel parses a CLI threshold.
 func ParseRiskLevel(s string) (query.RiskLevel, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
@@ -465,6 +557,39 @@ func ParseRiskLevel(s string) (query.RiskLevel, error) {
 		return query.RiskBlocked, nil
 	default:
 		return "", fmt.Errorf("unknown risk level %q", s)
+	}
+}
+
+// ParseAnalysisPrecision parses a CLI precision threshold.
+func ParseAnalysisPrecision(s string) (query.AnalysisPrecision, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return "", nil
+	case "precise":
+		return query.AnalysisPrecise, nil
+	case "partial":
+		return query.AnalysisPartial, nil
+	case "unsupported":
+		return query.AnalysisUnsupported, nil
+	default:
+		return "", fmt.Errorf("unknown analysis precision %q", s)
+	}
+}
+
+func comparePrecision(a, b query.AnalysisPrecision) int {
+	return precisionRank(a) - precisionRank(b)
+}
+
+func precisionRank(precision query.AnalysisPrecision) int {
+	switch precision {
+	case query.AnalysisPrecise, "":
+		return 0
+	case query.AnalysisPartial:
+		return 1
+	case query.AnalysisUnsupported:
+		return 2
+	default:
+		return 0
 	}
 }
 

--- a/orm/review/review_test.go
+++ b/orm/review/review_test.go
@@ -119,6 +119,89 @@ func TestRunReviewsStaleManifest(t *testing.T) {
 	}
 }
 
+func TestRunRequiresFreshManifestRejectsMissingAndUnverified(t *testing.T) {
+	dir := t.TempDir()
+	report, err := Run(Options{Paths: []string{dir}, RequireFreshManifest: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ManifestStatus == nil || report.ManifestStatus.State != "missing" {
+		t.Fatalf("expected missing manifest status, got %#v", report.ManifestStatus)
+	}
+	if !hasFinding(report.Findings, manifest.WarningRequired) {
+		t.Fatalf("expected %s finding, got %#v", manifest.WarningRequired, report.Findings)
+	}
+
+	m, err := manifest.Generate(manifest.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := m.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "goquent.manifest.json")
+	if err := os.WriteFile(manifestPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report, err = Run(Options{ManifestPath: manifestPath, RequireFreshManifest: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ManifestStatus == nil || report.ManifestStatus.State != "unverified" {
+		t.Fatalf("expected unverified manifest status, got %#v", report.ManifestStatus)
+	}
+	if !hasFinding(report.Findings, manifest.WarningUnverified) {
+		t.Fatalf("expected %s finding, got %#v", manifest.WarningUnverified, report.Findings)
+	}
+}
+
+func TestRunVerifiesManifestAgainstCurrentInputs(t *testing.T) {
+	dir := t.TempDir()
+	stored, err := manifest.Generate(manifest.Options{
+		Schema: &migration.Schema{Tables: []migration.TableSchema{{
+			Name:    "users",
+			Columns: []migration.ColumnSchema{{Name: "id", Type: "bigint"}},
+		}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := manifest.Generate(manifest.Options{
+		Schema: &migration.Schema{Tables: []migration.TableSchema{{
+			Name:    "users",
+			Columns: []migration.ColumnSchema{{Name: "id", Type: "bigint"}},
+		}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := stored.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "goquent.manifest.json")
+	if err := os.WriteFile(manifestPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Run(Options{
+		ManifestPath:         manifestPath,
+		RequireFreshManifest: true,
+		CurrentManifest:      current,
+		ManifestInputs:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ManifestStatus == nil || report.ManifestStatus.State != "fresh" || !report.ManifestStatus.Verified {
+		t.Fatalf("expected verified fresh manifest status, got %#v", report.ManifestStatus)
+	}
+	if hasFinding(report.Findings, manifest.WarningUnverified) || hasFinding(report.Findings, manifest.WarningStale) {
+		t.Fatalf("unexpected freshness finding: %#v", report.Findings)
+	}
+}
+
 func TestRunReviewsSuppressedWarningsFromQueryPlanJSON(t *testing.T) {
 	dir := t.TempDir()
 	plan := query.QueryPlan{
@@ -249,6 +332,53 @@ func run(q any, db any, sqlText string) {
 	}
 	if unsupported.AnalysisPrecision != query.AnalysisUnsupported {
 		t.Fatalf("expected unsupported precision, got %s", unsupported.AnalysisPrecision)
+	}
+}
+
+func TestRunReviewsGoSourceWithManifestPolicies(t *testing.T) {
+	dir := t.TempDir()
+	goPath := filepath.Join(dir, "repo.go")
+	src := `package sample
+
+func run(db any) {
+	var rows []map[string]any
+	db.Table("users").Select("id", "email").GetMaps(&rows)
+	db.Table("users").Where("tenant_id", "tenant-1").Update(map[string]any{"name": "x"})
+}
+`
+	if err := os.WriteFile(goPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &manifest.Manifest{Tables: []manifest.Table{{
+		Name:  "users",
+		Model: "User",
+		Columns: []manifest.Column{
+			{Name: "id", Primary: true},
+			{Name: "tenant_id", TenantScope: true, RequiredFilter: true},
+			{Name: "deleted_at", SoftDelete: true},
+			{Name: "email", PII: true},
+			{Name: "name"},
+		},
+		Policies: []manifest.Policy{
+			{Type: "tenant_scope", Column: "tenant_id", Mode: query.PolicyModeEnforce},
+			{Type: "soft_delete", Column: "deleted_at", Mode: query.PolicyModeEnforce},
+			{Type: "pii", Column: "email", Mode: query.PolicyModeWarn},
+		},
+	}}}
+
+	report, err := Run(Options{Paths: []string{goPath}, CurrentManifest: m, ManifestInputs: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{
+		query.WarningTenantFilterMissing,
+		query.WarningSoftDeleteFilterMissing,
+		query.WarningPIIColumnSelected,
+		query.WarningBulkUpdateDetected,
+	} {
+		if !hasFinding(report.Findings, code) {
+			t.Fatalf("expected %s finding, got %#v", code, report.Findings)
+		}
 	}
 }
 

--- a/orm/scope.go
+++ b/orm/scope.go
@@ -21,6 +21,18 @@ func CursorAsc(name string) CursorColumn { return query.CursorAsc(name) }
 // CursorDesc returns a descending keyset cursor column.
 func CursorDesc(name string) CursorColumn { return query.CursorDesc(name) }
 
+// CursorAscExpr returns an ascending trusted SQL expression cursor column.
+func CursorAscExpr(expr string) CursorColumn { return query.CursorAscExpr(expr) }
+
+// CursorDescExpr returns a descending trusted SQL expression cursor column.
+func CursorDescExpr(expr string) CursorColumn { return query.CursorDescExpr(expr) }
+
+// CursorAscAlias returns an ascending selected alias cursor column.
+func CursorAscAlias(alias string) CursorColumn { return query.CursorAscAlias(alias) }
+
+// CursorDescAlias returns a descending selected alias cursor column.
+func CursorDescAlias(alias string) CursorColumn { return query.CursorDescAlias(alias) }
+
 // ApplyScopes applies scopes to q in order. Nil scopes are ignored.
 // If a scope returns nil, the current query is kept.
 func ApplyScopes(q *query.Query, scopes ...Scope) *query.Query {
@@ -126,10 +138,17 @@ func UpdateBy(ctx context.Context, base *query.Query, data any, scopes ...Scope)
 
 // UpdateByReturning applies scopes, executes an UPDATE, and scans the Postgres RETURNING row into T.
 func UpdateByReturning[T any](ctx context.Context, db *DB, base *query.Query, data any, scopes ...Scope) (T, error) {
+	return UpdateByReturningWithOptions[T](ctx, db, base, data, nil, scopes...)
+}
+
+// UpdateByReturningWithOptions applies scopes, executes an UPDATE with
+// RETURNING, and applies write options such as NoRowsAs for guarded updates.
+func UpdateByReturningWithOptions[T any](ctx context.Context, db *DB, base *query.Query, data any, opts []WriteOpt, scopes ...Scope) (T, error) {
 	var zero T
 	if db == nil {
 		return zero, fmt.Errorf("db is nil")
 	}
+	o := applyWriteOpts(opts)
 	q, err := scopedQuery(base, scopes...)
 	if err != nil {
 		return zero, err
@@ -141,15 +160,18 @@ func UpdateByReturning[T any](ctx context.Context, db *DB, base *query.Query, da
 	if err := query.EnsurePlanExecutable(plan); err != nil {
 		return zero, err
 	}
-	cols, err := returningColumnsForQuery[T]()
+	if len(o.returning) == 0 {
+		cols, err := returningColumnsForQuery[T]()
+		if err != nil {
+			return zero, err
+		}
+		o.returning = cols
+	}
+	sqlStr, err := appendReturningClause(db.drv.Dialect, plan.SQL, o.returning)
 	if err != nil {
 		return zero, err
 	}
-	sqlStr, err := appendReturningClause(db.drv.Dialect, plan.SQL, cols)
-	if err != nil {
-		return zero, err
-	}
-	return queryReturningOne[T](ctx, db, sqlStr, plan.Params...)
+	return queryReturningOneWithOptions[T](ctx, db, sqlStr, o, plan.Params...)
 }
 
 // DeleteBy applies scopes to base and executes a DELETE using the resulting query.

--- a/orm/scope_test.go
+++ b/orm/scope_test.go
@@ -2,6 +2,7 @@ package orm
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -225,6 +226,32 @@ func TestUpdateByReturningAppliesScopes(t *testing.T) {
 	}
 	if row.ID != 1 || row.Name != "alice" || row.Age != 34 {
 		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpdateByReturningWithOptionsMapsNoRows(t *testing.T) {
+	ctx := context.Background()
+	db, mock := newReturningMockDB(t)
+
+	mock.ExpectQuery(`UPDATE "users" SET .* WHERE .* RETURNING "id", "name", "age"$`).
+		WithArgs("alice", 1, "hash-old").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}))
+
+	_, err := UpdateByReturningWithOptions[genericWriteUser](
+		ctx,
+		db,
+		db.Table("users"),
+		map[string]any{"name": "alice"},
+		[]WriteOpt{NoRowsAs(ErrConflict)},
+		func(q *query.Query) *query.Query {
+			return q.Where("id", 1).Where("content_hash", "hash-old")
+		},
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected conflict error, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/orm/select.go
+++ b/orm/select.go
@@ -139,7 +139,10 @@ func SelectAll[T any](ctx context.Context, db *DB, q string, args ...any) ([]T, 
 		return nil, err
 	}
 	defer rows.Close()
+	return scanRowsAll[T](db, rows)
+}
 
+func scanRowsAll[T any](db *DB, rows *sql.Rows) ([]T, error) {
 	var t T
 	typ := reflect.TypeOf(t)
 	switch {

--- a/orm/select_test.go
+++ b/orm/select_test.go
@@ -1,0 +1,24 @@
+package orm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestSelectOneReturnsErrNotFound(t *testing.T) {
+	ctx := context.Background()
+	db, mock := newReturningMockDB(t)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}))
+
+	_, err := SelectOne[genericWriteUser](ctx, db.RequireRawApproval("not found test"), "SELECT id, name, age FROM users WHERE id = $1", 42)
+	if !errors.Is(err, ErrNotFound) || !IsNotFound(err) {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/orm/write.go
+++ b/orm/write.go
@@ -23,6 +23,8 @@ type writeOptions struct {
 	wherePK            bool
 	returning          []string
 	table              string
+	tablePath          []string
+	schema             string
 	pkCols             map[string]struct{}
 	conflictCols       []string
 	conflictWhere      string
@@ -30,6 +32,27 @@ type writeOptions struct {
 	conflictTargetRaw  string
 	upsertUpdateCols   []string
 	hasUpsertUpdates   bool
+	conflictDoNothing  bool
+	assignments        []writeAssignment
+	expectAffected     *int64
+	zeroRowsErr        error
+}
+
+type writeAssignmentKind int
+
+const (
+	writeAssignmentRaw writeAssignmentKind = iota
+	writeAssignmentExpr
+	writeAssignmentColumn
+	writeAssignmentIncrement
+)
+
+type writeAssignment struct {
+	column       string
+	expression   string
+	args         []any
+	sourceColumn string
+	kind         writeAssignmentKind
 }
 
 // Columns limits write to specified columns.
@@ -103,11 +126,37 @@ func ConflictDoNothing() WriteOpt {
 	return func(o *writeOptions) {
 		o.upsertUpdateCols = nil
 		o.hasUpsertUpdates = true
+		o.conflictDoNothing = true
 	}
 }
 
 // Table sets table name (required for map writes).
-func Table(name string) WriteOpt { return func(o *writeOptions) { o.table = name } }
+func Table(name string) WriteOpt {
+	return func(o *writeOptions) {
+		o.table = name
+		o.tablePath = nil
+	}
+}
+
+// TablePath sets a schema-qualified or otherwise path-qualified table name.
+//
+// For example, TablePath("app", "users") renders "app"."users" on
+// PostgreSQL and `app`.`users` on MySQL.
+func TablePath(parts ...string) WriteOpt {
+	return func(o *writeOptions) {
+		o.tablePath = append([]string(nil), parts...)
+		o.table = strings.Join(parts, ".")
+		o.schema = ""
+	}
+}
+
+// SchemaName sets the schema for the write table. It can be combined with
+// Table("users") or an inferred struct table name.
+func SchemaName(name string) WriteOpt {
+	return func(o *writeOptions) {
+		o.schema = name
+	}
+}
 
 // PK specifies primary key columns for map writes.
 func PK(cols ...string) WriteOpt {
@@ -118,6 +167,70 @@ func PK(cols ...string) WriteOpt {
 		for _, c := range cols {
 			o.pkCols[c] = struct{}{}
 		}
+	}
+}
+
+// SetRaw adds a database-side assignment to Update or the conflict-update side
+// of Upsert. The expression is a trusted SQL fragment and must not contain
+// placeholders.
+func SetRaw(column, expression string) WriteOpt {
+	return func(o *writeOptions) {
+		o.assignments = append(o.assignments, writeAssignment{
+			column:     column,
+			expression: expression,
+			kind:       writeAssignmentRaw,
+		})
+	}
+}
+
+// SetExpr adds a database-side assignment with positional ? placeholders.
+// Placeholders are rewritten for the active dialect.
+func SetExpr(column, expression string, args ...any) WriteOpt {
+	return func(o *writeOptions) {
+		o.assignments = append(o.assignments, writeAssignment{
+			column:     column,
+			expression: expression,
+			args:       append([]any(nil), args...),
+			kind:       writeAssignmentExpr,
+		})
+	}
+}
+
+// SetColumn assigns one column from another column.
+func SetColumn(column, sourceColumn string) WriteOpt {
+	return func(o *writeOptions) {
+		o.assignments = append(o.assignments, writeAssignment{
+			column:       column,
+			sourceColumn: sourceColumn,
+			kind:         writeAssignmentColumn,
+		})
+	}
+}
+
+// Increment adds delta to column on Update or the conflict-update side of
+// Upsert.
+func Increment(column string, delta any) WriteOpt {
+	return func(o *writeOptions) {
+		o.assignments = append(o.assignments, writeAssignment{
+			column: column,
+			args:   []any{delta},
+			kind:   writeAssignmentIncrement,
+		})
+	}
+}
+
+// ExpectAffected requires the write to affect exactly n rows.
+func ExpectAffected(n int64) WriteOpt {
+	return func(o *writeOptions) {
+		o.expectAffected = &n
+	}
+}
+
+// NoRowsAs maps a zero-row write result to err. Use ErrConflict for explicit
+// optimistic-concurrency guards such as content_hash or version predicates.
+func NoRowsAs(err error) WriteOpt {
+	return func(o *writeOptions) {
+		o.zeroRowsErr = err
 	}
 }
 
@@ -154,6 +267,42 @@ func (o *writeOptions) isConflictColumn(col string) bool {
 
 func quote(d driver.Dialect, ident string) string { return d.QuoteIdent(ident) }
 
+func quoteIdentifierPath(d driver.Dialect, ident string) (string, error) {
+	return quoteIdentifierPathParts(d, strings.Split(ident, "."))
+}
+
+func quoteIdentifierPathParts(d driver.Dialect, parts []string) (string, error) {
+	if len(parts) == 0 {
+		return "", fmt.Errorf("goquent: identifier path is required")
+	}
+	quoted := make([]string, len(parts))
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", fmt.Errorf("goquent: identifier path contains an empty part")
+		}
+		quoted[i] = quote(d, part)
+	}
+	return strings.Join(quoted, "."), nil
+}
+
+func quoteWriteTable(d driver.Dialect, table string, o *writeOptions) (string, error) {
+	if len(o.tablePath) > 0 {
+		return quoteIdentifierPathParts(d, o.tablePath)
+	}
+	table = strings.TrimSpace(table)
+	if table == "" {
+		return "", fmt.Errorf("goquent: table name is required")
+	}
+	if schema := strings.TrimSpace(o.schema); schema != "" {
+		if strings.Contains(table, ".") {
+			return "", fmt.Errorf("goquent: Schema cannot be combined with schema-qualified table %q", table)
+		}
+		return quoteIdentifierPathParts(d, []string{schema, table})
+	}
+	return quoteIdentifierPath(d, table)
+}
+
 func buildPlaceholders(d driver.Dialect, n int, start int) []string {
 	ph := make([]string, n)
 	for i := 0; i < n; i++ {
@@ -183,7 +332,11 @@ func appendReturningClause(d driver.Dialect, sqlStr string, cols []string) (stri
 	}
 	rc := make([]string, len(cols))
 	for i, c := range cols {
-		rc[i] = quote(d, c)
+		quoted, err := quoteIdentifierPath(d, c)
+		if err != nil {
+			return "", err
+		}
+		rc[i] = quoted
 	}
 	return sqlStr + " RETURNING " + strings.Join(rc, ", "), nil
 }
@@ -238,8 +391,18 @@ func queryReturningOne[T any](ctx context.Context, db *DB, sqlStr string, args .
 	return scanRowsOne[T](db, rows)
 }
 
+func queryReturningOneWithOptions[T any](ctx context.Context, db *DB, sqlStr string, o *writeOptions, args ...any) (T, error) {
+	row, err := queryReturningOne[T](ctx, db, sqlStr, args...)
+	if err == nil || !IsNotFound(err) || o == nil || o.zeroRowsErr == nil {
+		return row, err
+	}
+	var zero T
+	return zero, RowsAffectedError{Expected: 1, Actual: 0, Cause: o.zeroRowsErr}
+}
+
 func ensureReturningColumns[T any](o *writeOptions) error {
-	if len(o.returning) > 0 {
+	returning := o != nil && len(o.returning) > 0
+	if returning {
 		return nil
 	}
 	cols, err := returningColumnsForQuery[T]()
@@ -269,11 +432,48 @@ func returningColumnsForQuery[T any]() ([]string, error) {
 	return cols, nil
 }
 
-func execWriteStatement(ctx context.Context, db *DB, sqlStr string, args []any, returning bool) (sql.Result, error) {
-	if returning {
-		return execReturningRows(ctx, db, sqlStr, args...)
+func execWriteStatement(ctx context.Context, db *DB, sqlStr string, args []any, o *writeOptions) (sql.Result, error) {
+	var (
+		res sql.Result
+		err error
+	)
+	if o != nil && len(o.returning) > 0 {
+		res, err = execReturningRows(ctx, db, sqlStr, args...)
+	} else {
+		res, err = db.execContextTrusted(ctx, sqlStr, args...)
 	}
-	return db.execContextTrusted(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkRowsAffected(res, o); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func checkRowsAffected(res sql.Result, o *writeOptions) error {
+	if res == nil || o == nil || (o.expectAffected == nil && o.zeroRowsErr == nil) {
+		return nil
+	}
+	actual, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if o.expectAffected != nil {
+		expected := *o.expectAffected
+		if actual == expected {
+			return nil
+		}
+		cause := ErrRowsAffected
+		if actual == 0 && o.zeroRowsErr != nil {
+			cause = o.zeroRowsErr
+		}
+		return RowsAffectedError{Expected: expected, Actual: actual, Cause: cause}
+	}
+	if actual == 0 && o.zeroRowsErr != nil {
+		return RowsAffectedError{Expected: 1, Actual: actual, Cause: o.zeroRowsErr}
+	}
+	return nil
 }
 
 func validateWriteRawSQLFragment(raw string) error {
@@ -296,6 +496,126 @@ func validateWriteRawSQLFragment(raw string) error {
 	return nil
 }
 
+func writeAssignmentTargets(assignments []writeAssignment) map[string]struct{} {
+	targets := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		column := strings.TrimSpace(assignment.column)
+		if column == "" {
+			continue
+		}
+		targets[column] = struct{}{}
+	}
+	return targets
+}
+
+func validateWriteAssignments(assignments []writeAssignment) error {
+	seen := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		column := strings.TrimSpace(assignment.column)
+		if column == "" {
+			return fmt.Errorf("goquent: assignment column is required")
+		}
+		if _, ok := seen[column]; ok {
+			return fmt.Errorf("goquent: duplicate assignment for column %s", column)
+		}
+		seen[column] = struct{}{}
+	}
+	return nil
+}
+
+func buildWriteSetParts(d driver.Dialect, setCols []string, setArgs []any, assignments []writeAssignment, start int) ([]string, []any, error) {
+	if err := validateWriteAssignments(assignments); err != nil {
+		return nil, nil, err
+	}
+	setParts := make([]string, 0, len(setCols)+len(assignments))
+	args := make([]any, 0, len(setArgs)+len(assignments))
+	argPos := start
+	for i, col := range setCols {
+		setParts = append(setParts, fmt.Sprintf("%s=%s", quote(d, col), d.Placeholder(argPos)))
+		args = append(args, setArgs[i])
+		argPos++
+	}
+	for _, assignment := range assignments {
+		target, err := quoteIdentifierPath(d, assignment.column)
+		if err != nil {
+			return nil, nil, err
+		}
+		expr, exprArgs, err := renderWriteAssignment(d, assignment, argPos)
+		if err != nil {
+			return nil, nil, err
+		}
+		setParts = append(setParts, fmt.Sprintf("%s=%s", target, expr))
+		args = append(args, exprArgs...)
+		argPos += len(exprArgs)
+	}
+	return setParts, args, nil
+}
+
+func renderWriteAssignment(d driver.Dialect, assignment writeAssignment, start int) (string, []any, error) {
+	switch assignment.kind {
+	case writeAssignmentRaw:
+		if len(assignment.args) > 0 {
+			return "", nil, fmt.Errorf("goquent: SetRaw does not accept args")
+		}
+		expr := strings.TrimSpace(assignment.expression)
+		if err := validateWriteRawSQLFragment(expr); err != nil {
+			return "", nil, err
+		}
+		if strings.Contains(expr, "?") {
+			return "", nil, fmt.Errorf("goquent: SetRaw expression contains placeholders; use SetExpr")
+		}
+		return expr, nil, nil
+	case writeAssignmentExpr:
+		expr := strings.TrimSpace(assignment.expression)
+		if err := validateWriteRawSQLFragment(expr); err != nil {
+			return "", nil, err
+		}
+		rendered, err := renderWriteExpressionPlaceholders(d, expr, len(assignment.args), start)
+		if err != nil {
+			return "", nil, err
+		}
+		return rendered, append([]any(nil), assignment.args...), nil
+	case writeAssignmentColumn:
+		if len(assignment.args) > 0 {
+			return "", nil, fmt.Errorf("goquent: SetColumn does not accept args")
+		}
+		expr, err := quoteIdentifierPath(d, assignment.sourceColumn)
+		return expr, nil, err
+	case writeAssignmentIncrement:
+		if len(assignment.args) != 1 {
+			return "", nil, fmt.Errorf("goquent: Increment requires one delta arg")
+		}
+		target, err := quoteIdentifierPath(d, assignment.column)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("%s + %s", target, d.Placeholder(start)), append([]any(nil), assignment.args...), nil
+	default:
+		return "", nil, fmt.Errorf("goquent: unknown assignment kind")
+	}
+}
+
+func renderWriteExpressionPlaceholders(d driver.Dialect, expr string, argCount int, start int) (string, error) {
+	if strings.Count(expr, "?") != argCount {
+		return "", fmt.Errorf("goquent: SetExpr placeholder count does not match args")
+	}
+	if argCount == 0 {
+		return expr, nil
+	}
+	var b strings.Builder
+	b.Grow(len(expr) + argCount*2)
+	argIndex := 0
+	for i := 0; i < len(expr); i++ {
+		if expr[i] != '?' {
+			b.WriteByte(expr[i])
+			continue
+		}
+		b.WriteString(d.Placeholder(start + argIndex))
+		argIndex++
+	}
+	return b.String(), nil
+}
+
 // Insert inserts v into its table.
 func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Result, error) {
 	o := applyWriteOpts(opts)
@@ -303,7 +623,7 @@ func Insert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	if err != nil {
 		return nil, err
 	}
-	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+	return execWriteStatement(ctx, db, sqlStr, args, o)
 }
 
 // InsertReturning inserts v and scans the Postgres RETURNING row into T.
@@ -317,10 +637,13 @@ func InsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...Wri
 	if err != nil {
 		return zero, err
 	}
-	return queryReturningOne[T](ctx, db, sqlStr, args...)
+	return queryReturningOneWithOptions[T](ctx, db, sqlStr, o, args...)
 }
 
 func buildInsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
+	if len(o.assignments) > 0 {
+		return "", nil, fmt.Errorf("assignment options are not supported for Insert")
+	}
 	val := reflect.ValueOf(v)
 	typ := val.Type()
 	var table string
@@ -385,8 +708,12 @@ func buildInsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	for i, c := range cols {
 		quotedCols[i] = quote(db.drv.Dialect, c)
 	}
-	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
-	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
+	tableSQL, err := quoteWriteTable(db.drv.Dialect, table, o)
+	if err != nil {
+		return "", nil, err
+	}
+	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", tableSQL, strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	sqlStr, err = appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
 		return "", nil, err
 	}
@@ -400,7 +727,7 @@ func Update[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	if err != nil {
 		return nil, err
 	}
-	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+	return execWriteStatement(ctx, db, sqlStr, args, o)
 }
 
 // UpdateReturning updates v and scans the Postgres RETURNING row into T.
@@ -414,13 +741,14 @@ func UpdateReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...Wri
 	if err != nil {
 		return zero, err
 	}
-	return queryReturningOne[T](ctx, db, sqlStr, args...)
+	return queryReturningOneWithOptions[T](ctx, db, sqlStr, o, args...)
 }
 
 func buildUpdateStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	if !o.wherePK {
 		return "", nil, fmt.Errorf("Update[T] without WherePK is not allowed")
 	}
+	assignmentTargets := writeAssignmentTargets(o.assignments)
 	val := reflect.ValueOf(v)
 	typ := val.Type()
 	var table string
@@ -446,6 +774,9 @@ func buildUpdateStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 			if o.isPK(col) {
 				whereCols = append(whereCols, col)
 				whereArgs = append(whereArgs, v.Interface())
+				continue
+			}
+			if _, ok := assignmentTargets[col]; ok {
 				continue
 			}
 			if len(o.cols) > 0 {
@@ -483,6 +814,9 @@ func buildUpdateStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 			if fm.Readonly {
 				continue
 			}
+			if _, ok := assignmentTargets[fm.Col]; ok {
+				continue
+			}
 			if len(o.cols) > 0 {
 				if _, ok := o.cols[fm.Col]; !ok {
 					continue
@@ -503,20 +837,24 @@ func buildUpdateStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	if len(whereCols) == 0 {
 		return "", nil, fmt.Errorf("WherePK requires pk values")
 	}
-	if len(setCols) == 0 {
+	if len(setCols) == 0 && len(o.assignments) == 0 {
 		return "", nil, fmt.Errorf("no columns to update")
 	}
-	setParts := make([]string, len(setCols))
-	for i, col := range setCols {
-		setParts[i] = fmt.Sprintf("%s=%s", quote(db.drv.Dialect, col), db.drv.Dialect.Placeholder(i+1))
+	setParts, setArgs, err := buildWriteSetParts(db.drv.Dialect, setCols, setArgs, o.assignments, 1)
+	if err != nil {
+		return "", nil, err
 	}
 	whereParts := make([]string, len(whereCols))
 	for i, col := range whereCols {
 		whereParts[i] = fmt.Sprintf("%s=%s", quote(db.drv.Dialect, col), db.drv.Dialect.Placeholder(len(setArgs)+i+1))
 	}
 	args := append(append([]any(nil), setArgs...), whereArgs...)
-	sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE %s", quote(db.drv.Dialect, table), strings.Join(setParts, ", "), strings.Join(whereParts, " AND "))
-	sqlStr, err := appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
+	tableSQL, err := quoteWriteTable(db.drv.Dialect, table, o)
+	if err != nil {
+		return "", nil, err
+	}
+	sqlStr := fmt.Sprintf("UPDATE %s SET %s WHERE %s", tableSQL, strings.Join(setParts, ", "), strings.Join(whereParts, " AND "))
+	sqlStr, err = appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
 		return "", nil, err
 	}
@@ -530,7 +868,7 @@ func Upsert[T any](ctx context.Context, db *DB, v T, opts ...WriteOpt) (sql.Resu
 	if err != nil {
 		return nil, err
 	}
-	return execWriteStatement(ctx, db, sqlStr, args, len(o.returning) > 0)
+	return execWriteStatement(ctx, db, sqlStr, args, o)
 }
 
 // UpsertReturning upserts v and scans the Postgres RETURNING row into T.
@@ -544,7 +882,7 @@ func UpsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...Wri
 	if err != nil {
 		return zero, err
 	}
-	return queryReturningOne[T](ctx, db, sqlStr, args...)
+	return queryReturningOneWithOptions[T](ctx, db, sqlStr, o, args...)
 }
 
 // InsertOnceReturning inserts v once and scans the inserted or existing row.
@@ -561,6 +899,7 @@ func InsertOnceReturning[T any, V any](ctx context.Context, db *DB, v V, opts ..
 	}
 	o.upsertUpdateCols = nil
 	o.hasUpsertUpdates = true
+	o.conflictDoNothing = true
 
 	sqlStr, args, err := buildUpsertStatement(db, v, o)
 	if err != nil {
@@ -584,6 +923,9 @@ func InsertOnceReturning[T any, V any](ctx context.Context, db *DB, v V, opts ..
 func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	if !o.wherePK && !o.hasConflictTarget() {
 		return "", nil, fmt.Errorf("Upsert[T] requires WherePK, ConflictColumns, or ConflictConstraint")
+	}
+	if o.conflictDoNothing && len(o.assignments) > 0 {
+		return "", nil, fmt.Errorf("ConflictDoNothing cannot be combined with assignment options")
 	}
 	val := reflect.ValueOf(v)
 	typ := val.Type()
@@ -691,9 +1033,17 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	for i, c := range cols {
 		quotedCols[i] = quote(db.drv.Dialect, c)
 	}
-	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", quote(db.drv.Dialect, table), strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	tableSQL, err := quoteWriteTable(db.drv.Dialect, table, o)
+	if err != nil {
+		return "", nil, err
+	}
+	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", tableSQL, strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
 	targetCols := conflictTargetColumns(o, pkCols)
 	updateCols, err := upsertUpdateColumns(cols, targetCols, o)
+	if err != nil {
+		return "", nil, err
+	}
+	assignmentParts, assignmentArgs, err := buildWriteSetParts(db.drv.Dialect, nil, nil, o.assignments, len(args)+1)
 	if err != nil {
 		return "", nil, err
 	}
@@ -702,11 +1052,12 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 		if strings.TrimSpace(o.conflictWhere) != "" || strings.TrimSpace(o.conflictConstraint) != "" || strings.TrimSpace(o.conflictTargetRaw) != "" {
 			return "", nil, fmt.Errorf("ConflictWhere, ConflictConstraint, and ConflictTargetRaw are not supported on dialect: %T", db.drv.Dialect)
 		}
-		if len(updateCols) > 0 {
-			assigns := make([]string, len(updateCols))
-			for i, c := range updateCols {
-				assigns[i] = fmt.Sprintf("%s=VALUES(%s)", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c))
+		if len(updateCols) > 0 || len(assignmentParts) > 0 {
+			assigns := make([]string, 0, len(updateCols)+len(assignmentParts))
+			for _, c := range updateCols {
+				assigns = append(assigns, fmt.Sprintf("%s=VALUES(%s)", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c)))
 			}
+			assigns = append(assigns, assignmentParts...)
 			sqlStr += " ON DUPLICATE KEY UPDATE " + strings.Join(assigns, ", ")
 		} else {
 			sqlStr = strings.Replace(sqlStr, "INSERT", "INSERT IGNORE", 1)
@@ -716,11 +1067,12 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 		if err != nil {
 			return "", nil, err
 		}
-		if len(updateCols) > 0 {
-			assigns := make([]string, len(updateCols))
-			for i, c := range updateCols {
-				assigns[i] = fmt.Sprintf("%s=EXCLUDED.%s", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c))
+		if len(updateCols) > 0 || len(assignmentParts) > 0 {
+			assigns := make([]string, 0, len(updateCols)+len(assignmentParts))
+			for _, c := range updateCols {
+				assigns = append(assigns, fmt.Sprintf("%s=EXCLUDED.%s", quote(db.drv.Dialect, c), quote(db.drv.Dialect, c)))
 			}
+			assigns = append(assigns, assignmentParts...)
 			sqlStr += fmt.Sprintf(" ON CONFLICT %s DO UPDATE SET %s", target, strings.Join(assigns, ", "))
 		} else {
 			sqlStr += fmt.Sprintf(" ON CONFLICT %s DO NOTHING", target)
@@ -732,6 +1084,7 @@ func buildUpsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 	if err != nil {
 		return "", nil, err
 	}
+	args = append(args, assignmentArgs...)
 	return sqlStr, args, nil
 }
 
@@ -822,8 +1175,10 @@ func conflictTargetColumns(o *writeOptions, pkCols []string) []string {
 }
 
 func upsertUpdateColumns(cols []string, targetCols []string, o *writeOptions) ([]string, error) {
+	assignmentTargets := writeAssignmentTargets(o.assignments)
 	if o.hasUpsertUpdates {
 		updateCols := dedupeColumns(o.upsertUpdateCols)
+		updateCols = filterColumns(updateCols, assignmentTargets)
 		if err := ensureUpsertUpdateColumnsPresent(updateCols, cols); err != nil {
 			return nil, err
 		}
@@ -838,9 +1193,26 @@ func upsertUpdateColumns(cols []string, targetCols []string, o *writeOptions) ([
 		if _, ok := target[col]; ok {
 			continue
 		}
+		if _, ok := assignmentTargets[col]; ok {
+			continue
+		}
 		updateCols = append(updateCols, col)
 	}
 	return updateCols, nil
+}
+
+func filterColumns(cols []string, excluded map[string]struct{}) []string {
+	if len(excluded) == 0 {
+		return cols
+	}
+	out := make([]string, 0, len(cols))
+	for _, col := range cols {
+		if _, ok := excluded[col]; ok {
+			continue
+		}
+		out = append(out, col)
+	}
+	return out
 }
 
 func dedupeColumns(cols []string) []string {

--- a/orm/write.go
+++ b/orm/write.go
@@ -391,6 +391,15 @@ func queryReturningOne[T any](ctx context.Context, db *DB, sqlStr string, args .
 	return scanRowsOne[T](db, rows)
 }
 
+func queryReturningAll[T any](ctx context.Context, db *DB, sqlStr string, args ...any) ([]T, error) {
+	rows, err := db.queryContextTrusted(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanRowsAll[T](db, rows)
+}
+
 func queryReturningOneWithOptions[T any](ctx context.Context, db *DB, sqlStr string, o *writeOptions, args ...any) (T, error) {
 	row, err := queryReturningOne[T](ctx, db, sqlStr, args...)
 	if err == nil || !IsNotFound(err) || o == nil || o.zeroRowsErr == nil {
@@ -640,6 +649,35 @@ func InsertReturning[T any, V any](ctx context.Context, db *DB, v V, opts ...Wri
 	return queryReturningOneWithOptions[T](ctx, db, sqlStr, o, args...)
 }
 
+// InsertMany inserts all values in one INSERT statement.
+//
+// Empty slices return an error instead of a no-op result. Map writes require
+// Table, and every row must provide the selected column set.
+func InsertMany[T any](ctx context.Context, db *DB, values []T, opts ...WriteOpt) (sql.Result, error) {
+	o := applyWriteOpts(opts)
+	sqlStr, args, err := buildInsertManyStatement(db, values, o)
+	if err != nil {
+		return nil, err
+	}
+	return execWriteStatement(ctx, db, sqlStr, args, o)
+}
+
+// InsertManyReturning inserts all values and scans PostgreSQL RETURNING rows.
+func InsertManyReturning[R any, T any](ctx context.Context, db *DB, values []T, opts ...WriteOpt) ([]R, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("goquent: no rows to insert")
+	}
+	o := applyWriteOpts(opts)
+	if err := ensureReturningColumns[R](o); err != nil {
+		return nil, err
+	}
+	sqlStr, args, err := buildInsertManyStatement(db, values, o)
+	if err != nil {
+		return nil, err
+	}
+	return queryReturningAll[R](ctx, db, sqlStr, args...)
+}
+
 func buildInsertStatement(db *DB, v any, o *writeOptions) (string, []any, error) {
 	if len(o.assignments) > 0 {
 		return "", nil, fmt.Errorf("assignment options are not supported for Insert")
@@ -713,6 +751,221 @@ func buildInsertStatement(db *DB, v any, o *writeOptions) (string, []any, error)
 		return "", nil, err
 	}
 	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", tableSQL, strings.Join(quotedCols, ", "), strings.Join(ph, ", "))
+	sqlStr, err = appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
+	if err != nil {
+		return "", nil, err
+	}
+	return sqlStr, args, nil
+}
+
+func buildInsertManyStatement[T any](db *DB, values []T, o *writeOptions) (string, []any, error) {
+	if len(values) == 0 {
+		return "", nil, fmt.Errorf("goquent: no rows to insert")
+	}
+	if err := validateInsertManyOptions(o); err != nil {
+		return "", nil, err
+	}
+
+	first := reflect.ValueOf(values[0])
+	if !first.IsValid() {
+		return "", nil, fmt.Errorf("unsupported type <nil>")
+	}
+	typ := first.Type()
+
+	var (
+		table string
+		cols  []string
+		args  []any
+		err   error
+	)
+	switch {
+	case isMapStringInterface(typ):
+		if o.table == "" {
+			return "", nil, fmt.Errorf("Table option required for map writes")
+		}
+		table = o.table
+		cols, args, err = insertManyMapColumnsAndArgs(values, o)
+	case typ.Kind() == reflect.Struct:
+		table = o.table
+		if table == "" {
+			table = model.TableName(values[0])
+		}
+		cols, args, err = insertManyStructColumnsAndArgs(values, typ, o)
+	default:
+		return "", nil, fmt.Errorf("unsupported type %s", typ)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	return buildInsertManySQL(db, table, cols, len(values), args, o)
+}
+
+func validateInsertManyOptions(o *writeOptions) error {
+	if len(o.assignments) > 0 {
+		return fmt.Errorf("assignment options are not supported for InsertMany")
+	}
+	if len(o.conflictCols) > 0 ||
+		strings.TrimSpace(o.conflictWhere) != "" ||
+		strings.TrimSpace(o.conflictConstraint) != "" ||
+		strings.TrimSpace(o.conflictTargetRaw) != "" ||
+		o.hasUpsertUpdates ||
+		o.conflictDoNothing {
+		return fmt.Errorf("conflict/upsert options are not supported for InsertMany")
+	}
+	return nil
+}
+
+func insertManyStructColumnsAndArgs[T any](values []T, typ reflect.Type, o *writeOptions) ([]string, []any, error) {
+	var cols []string
+	args := make([]any, 0, len(values))
+	for i, row := range values {
+		val := reflect.ValueOf(row)
+		if !val.IsValid() {
+			return nil, nil, fmt.Errorf("goquent: InsertMany row %d is nil", i)
+		}
+		if val.Type() != typ {
+			return nil, nil, fmt.Errorf("goquent: InsertMany row %d has type %s, expected %s", i, val.Type(), typ)
+		}
+		rowCols, rowArgs, err := insertStructColumnsAndArgs(val, o)
+		if err != nil {
+			return nil, nil, err
+		}
+		if i == 0 {
+			cols = rowCols
+		} else if !sameColumns(cols, rowCols) {
+			return nil, nil, fmt.Errorf("goquent: InsertMany requires identical columns in every row")
+		}
+		args = append(args, rowArgs...)
+	}
+	if len(cols) == 0 {
+		return nil, nil, fmt.Errorf("no columns to insert")
+	}
+	return cols, args, nil
+}
+
+func insertStructColumnsAndArgs(val reflect.Value, o *writeOptions) ([]string, []any, error) {
+	meta, err := getTypeMeta(val.Type())
+	if err != nil {
+		return nil, nil, err
+	}
+	cols := make([]string, 0, len(meta.Fields))
+	args := make([]any, 0, len(meta.Fields))
+	for _, fm := range meta.Fields {
+		if fm.Readonly {
+			continue
+		}
+		if len(o.cols) > 0 {
+			if _, ok := o.cols[fm.Col]; !ok {
+				continue
+			}
+		}
+		if _, ok := o.omit[fm.Col]; ok {
+			continue
+		}
+		fv := val.FieldByIndex(fm.IndexPath)
+		if fm.OmitEmpty && fv.IsZero() {
+			continue
+		}
+		cols = append(cols, fm.Col)
+		args = append(args, fv.Interface())
+	}
+	return cols, args, nil
+}
+
+func insertManyMapColumnsAndArgs[T any](values []T, o *writeOptions) ([]string, []any, error) {
+	first := reflect.ValueOf(values[0])
+	cols := mapInsertManyColumnSet(first, o)
+	if len(cols) == 0 {
+		return nil, nil, fmt.Errorf("no columns to insert")
+	}
+	requireExact := len(o.cols) == 0
+	args := make([]any, 0, len(values)*len(cols))
+	for i, row := range values {
+		val := reflect.ValueOf(row)
+		if !val.IsValid() {
+			return nil, nil, fmt.Errorf("goquent: InsertMany map row %d is nil", i)
+		}
+		if !isMapStringInterface(val.Type()) {
+			return nil, nil, fmt.Errorf("goquent: InsertMany row %d has type %s, expected %s", i, val.Type(), first.Type())
+		}
+		if requireExact && !sameColumns(cols, mapInsertManyColumnSet(val, o)) {
+			return nil, nil, fmt.Errorf("goquent: InsertMany map row %d has inconsistent columns", i)
+		}
+		rowArgs, err := mapInsertManyRowArgs(val, cols, i)
+		if err != nil {
+			return nil, nil, err
+		}
+		args = append(args, rowArgs...)
+	}
+	return cols, args, nil
+}
+
+func mapInsertManyColumnSet(val reflect.Value, o *writeOptions) []string {
+	if len(o.cols) > 0 {
+		cols := make([]string, 0, len(o.cols))
+		for col := range o.cols {
+			if _, omitted := o.omit[col]; omitted {
+				continue
+			}
+			cols = append(cols, col)
+		}
+		sort.Strings(cols)
+		return cols
+	}
+	cols := make([]string, 0, val.Len())
+	iter := val.MapRange()
+	for iter.Next() {
+		col := iter.Key().String()
+		if _, omitted := o.omit[col]; omitted {
+			continue
+		}
+		cols = append(cols, col)
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+func mapInsertManyRowArgs(val reflect.Value, cols []string, row int) ([]any, error) {
+	args := make([]any, 0, len(cols))
+	for _, col := range cols {
+		mv := val.MapIndex(reflect.ValueOf(col))
+		if !mv.IsValid() {
+			return nil, fmt.Errorf("goquent: InsertMany map row %d missing column %s", row, col)
+		}
+		args = append(args, mv.Interface())
+	}
+	return args, nil
+}
+
+func sameColumns(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func buildInsertManySQL(db *DB, table string, cols []string, rowCount int, args []any, o *writeOptions) (string, []any, error) {
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = quote(db.drv.Dialect, c)
+	}
+	values := make([]string, rowCount)
+	argPos := 1
+	for i := 0; i < rowCount; i++ {
+		ph := buildPlaceholders(db.drv.Dialect, len(cols), argPos)
+		values[i] = "(" + strings.Join(ph, ", ") + ")"
+		argPos += len(cols)
+	}
+	tableSQL, err := quoteWriteTable(db.drv.Dialect, table, o)
+	if err != nil {
+		return "", nil, err
+	}
+	sqlStr := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s", tableSQL, strings.Join(quotedCols, ", "), strings.Join(values, ", "))
 	sqlStr, err = appendReturningClause(db.drv.Dialect, sqlStr, o.returning)
 	if err != nil {
 		return "", nil, err

--- a/orm/write_test.go
+++ b/orm/write_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -294,6 +295,196 @@ func TestInsertReturningMapUsesExplicitColumns(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestInsertManyStructBuildsSingleStatement(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]genericWriteUser{
+			{Name: "alice", Age: 30},
+			{Name: "bob", Age: 31},
+		},
+		Columns("name", "age"),
+	)
+	if err != nil {
+		t.Fatalf("insert many struct: %v", err)
+	}
+	wantSQL := "INSERT INTO `users` (`name`, `age`) VALUES (?, ?), (?, ?)"
+	if exec.query != wantSQL {
+		t.Fatalf("unexpected query:\nwant %s\ngot  %s", wantSQL, exec.query)
+	}
+	wantArgs := []any{"alice", 30, "bob", 31}
+	if !reflect.DeepEqual(exec.args, wantArgs) {
+		t.Fatalf("unexpected args: %#v", exec.args)
+	}
+}
+
+func TestInsertManyMapBuildsSingleStatement(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]map[string]any{
+			{"name": "alice", "age": 30},
+			{"name": "bob", "age": 31},
+		},
+		Table("users"),
+	)
+	if err != nil {
+		t.Fatalf("insert many map: %v", err)
+	}
+	wantSQL := "INSERT INTO `users` (`age`, `name`) VALUES (?, ?), (?, ?)"
+	if exec.query != wantSQL {
+		t.Fatalf("unexpected query:\nwant %s\ngot  %s", wantSQL, exec.query)
+	}
+	wantArgs := []any{30, "alice", 31, "bob"}
+	if !reflect.DeepEqual(exec.args, wantArgs) {
+		t.Fatalf("unexpected args: %#v", exec.args)
+	}
+}
+
+func TestInsertManyPostgresPlaceholderNumbering(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]genericWriteUser{
+			{Name: "alice", Age: 30},
+			{Name: "bob", Age: 31},
+		},
+		Columns("name", "age"),
+	)
+	if err != nil {
+		t.Fatalf("insert many postgres: %v", err)
+	}
+	wantSQL := `INSERT INTO "users" ("name", "age") VALUES ($1, $2), ($3, $4)`
+	if exec.query != wantSQL {
+		t.Fatalf("unexpected query:\nwant %s\ngot  %s", wantSQL, exec.query)
+	}
+}
+
+func TestInsertManyTablePathOption(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]map[string]any{
+			{"name": "alice"},
+			{"name": "bob"},
+		},
+		TablePath("app", "users"),
+	)
+	if err != nil {
+		t.Fatalf("insert many table path: %v", err)
+	}
+	if !strings.Contains(exec.query, `INSERT INTO "app"."users"`) {
+		t.Fatalf("expected table path, got: %s", exec.query)
+	}
+}
+
+func TestInsertManyEmptySliceReturnsError(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany[genericWriteUser](context.Background(), db, nil)
+	if err == nil || !strings.Contains(err.Error(), "goquent: no rows to insert") {
+		t.Fatalf("expected no rows error, got: %v", err)
+	}
+}
+
+func TestInsertManyMapRejectsInconsistentKeys(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]map[string]any{
+			{"name": "alice"},
+			{"name": "bob", "age": 31},
+		},
+		Table("users"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "inconsistent columns") {
+		t.Fatalf("expected inconsistent map columns error, got: %v", err)
+	}
+}
+
+func TestInsertManyReturningTypedStructScan(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	sqlText := `INSERT INTO "users" ("name", "age") VALUES ($1, $2), ($3, $4) RETURNING "id", "name", "age"`
+	mock.ExpectQuery(regexp.QuoteMeta(sqlText)).
+		WithArgs("alice", 30, "bob", 31).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}).
+			AddRow(1, "alice", 30).
+			AddRow(2, "bob", 31))
+
+	rows, err := InsertManyReturning[genericWriteUser](
+		context.Background(),
+		db,
+		[]genericWriteUser{
+			{Name: "alice", Age: 30},
+			{Name: "bob", Age: 31},
+		},
+		Columns("name", "age"),
+	)
+	if err != nil {
+		t.Fatalf("insert many returning: %v", err)
+	}
+	if len(rows) != 2 || rows[0].ID != 1 || rows[1].Name != "bob" {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestInsertManyReturningMapRequiresReturning(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertManyReturning[map[string]any](
+		context.Background(),
+		db,
+		[]map[string]any{{"name": "alice"}},
+		Table("users"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "Returning columns are required for map return values") {
+		t.Fatalf("expected returning columns error, got: %v", err)
+	}
+}
+
+func TestInsertManyRejectsAssignmentOptions(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]map[string]any{{"name": "alice"}},
+		Table("users"),
+		SetRaw("updated_at", "now()"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "assignment options are not supported for InsertMany") {
+		t.Fatalf("expected assignment insert many error, got: %v", err)
+	}
+}
+
+func TestInsertManyRejectsConflictOptions(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := InsertMany(
+		context.Background(),
+		db,
+		[]map[string]any{{"id": 1, "name": "alice"}},
+		Table("users"),
+		ConflictColumns("id"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "conflict/upsert options are not supported for InsertMany") {
+		t.Fatalf("expected conflict insert many error, got: %v", err)
 	}
 }
 

--- a/orm/write_test.go
+++ b/orm/write_test.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,8 +13,10 @@ import (
 )
 
 type captureExecutor struct {
-	query string
-	args  []any
+	query           string
+	args            []any
+	rowsAffected    int64
+	rowsAffectedSet bool
 }
 
 func (e *captureExecutor) Query(string, ...any) (*sql.Rows, error) { return nil, nil }
@@ -26,19 +29,29 @@ func (e *captureExecutor) QueryRow(string, ...any) *sql.Row { return nil }
 
 func (e *captureExecutor) QueryRowContext(context.Context, string, ...any) *sql.Row { return nil }
 
-func (e *captureExecutor) Exec(string, ...any) (sql.Result, error) { return captureResult{}, nil }
+func (e *captureExecutor) Exec(string, ...any) (sql.Result, error) {
+	return captureResult{rowsAffected: e.rowsAffected, rowsAffectedSet: e.rowsAffectedSet}, nil
+}
 
 func (e *captureExecutor) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
 	e.query = query
 	e.args = append([]any(nil), args...)
-	return captureResult{}, nil
+	return captureResult{rowsAffected: e.rowsAffected, rowsAffectedSet: e.rowsAffectedSet}, nil
 }
 
-type captureResult struct{}
+type captureResult struct {
+	rowsAffected    int64
+	rowsAffectedSet bool
+}
 
 func (captureResult) LastInsertId() (int64, error) { return 0, nil }
 
-func (captureResult) RowsAffected() (int64, error) { return 1, nil }
+func (r captureResult) RowsAffected() (int64, error) {
+	if !r.rowsAffectedSet {
+		return 1, nil
+	}
+	return r.rowsAffected, nil
+}
 
 func newCaptureWriteDB(d driver.Dialect) (*DB, *captureExecutor) {
 	exec := &captureExecutor{}
@@ -175,6 +188,47 @@ func TestUpdateMapUsesSetArgsBeforePKArgs(t *testing.T) {
 	}
 }
 
+func TestUpdateExpectAffectedMapsZeroRowsToConflict(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
+	exec.rowsAffected = 0
+	exec.rowsAffectedSet = true
+
+	_, err := Update(
+		context.Background(),
+		db,
+		genericWriteUser{ID: 3, Name: "alice"},
+		Columns("name"),
+		WherePK(),
+		ExpectAffected(1),
+		NoRowsAs(ErrConflict),
+	)
+	if !errors.Is(err, ErrConflict) || !IsConflict(err) {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+	var affected RowsAffectedError
+	if !errors.As(err, &affected) || affected.Expected != 1 || affected.Actual != 0 {
+		t.Fatalf("expected rows affected details, got %#v", err)
+	}
+}
+
+func TestUpdateExpectAffectedMismatch(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
+	exec.rowsAffected = 2
+	exec.rowsAffectedSet = true
+
+	_, err := Update(
+		context.Background(),
+		db,
+		genericWriteUser{ID: 3, Name: "alice"},
+		Columns("name"),
+		WherePK(),
+		ExpectAffected(1),
+	)
+	if !errors.Is(err, ErrRowsAffected) {
+		t.Fatalf("expected rows affected error, got %v", err)
+	}
+}
+
 func TestInsertReturningPostgresAddsClause(t *testing.T) {
 	db, mock := newReturningMockDB(t)
 	mock.ExpectQuery(`INSERT INTO "users".*RETURNING "id", "name"$`).
@@ -284,6 +338,27 @@ func TestUpdateReturningTypedInfersColumns(t *testing.T) {
 	}
 	if row.ID != 3 || row.Name != "alice" || row.Age != 31 {
 		t.Fatalf("unexpected row: %+v", row)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpdateReturningNoRowsAsConflict(t *testing.T) {
+	db, mock := newReturningMockDB(t)
+	mock.ExpectQuery(`UPDATE "users" SET .* RETURNING "id", "name", "age"$`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "age"}))
+
+	_, err := UpdateReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 3, Name: "alice"},
+		Columns("name"),
+		WherePK(),
+		NoRowsAs(ErrConflict),
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected conflict error, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -532,5 +607,190 @@ func TestUpsertPostgresConflictConstraint(t *testing.T) {
 	}
 	if !strings.Contains(exec.query, `ON CONFLICT ON CONSTRAINT "users_name_key" DO UPDATE SET`) {
 		t.Fatalf("expected named constraint conflict target, got: %s", exec.query)
+	}
+}
+
+func TestGenericWriteQuotesSchemaQualifiedTable(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Insert(
+		context.Background(),
+		db,
+		map[string]any{"name": "alice"},
+		Table("app.users"),
+	)
+	if err != nil {
+		t.Fatalf("insert schema-qualified table: %v", err)
+	}
+	if !strings.Contains(exec.query, `INSERT INTO "app"."users"`) {
+		t.Fatalf("expected schema-qualified table path, got: %s", exec.query)
+	}
+}
+
+func TestGenericWriteTablePathOption(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.MySQLDialect{})
+
+	_, err := Insert(
+		context.Background(),
+		db,
+		map[string]any{"name": "alice"},
+		TablePath("app", "users"),
+	)
+	if err != nil {
+		t.Fatalf("insert table path: %v", err)
+	}
+	if !strings.Contains(exec.query, "INSERT INTO `app`.`users`") {
+		t.Fatalf("expected table path, got: %s", exec.query)
+	}
+}
+
+func TestGenericWriteSchemaNameOption(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Insert(
+		context.Background(),
+		db,
+		genericWriteUser{Name: "alice"},
+		SchemaName("app"),
+		Columns("name"),
+	)
+	if err != nil {
+		t.Fatalf("insert schema name: %v", err)
+	}
+	if !strings.Contains(exec.query, `INSERT INTO "app"."users"`) {
+		t.Fatalf("expected schema name table path, got: %s", exec.query)
+	}
+}
+
+func TestNewDBWithExecutorUsesExternalExecutor(t *testing.T) {
+	exec := &captureExecutor{}
+	db := NewDBWithExecutor(exec, driver.PostgresDialect{})
+	defer db.Close()
+
+	if db.SQLDB() != nil {
+		t.Fatalf("external executor DB should not expose sql.DB")
+	}
+	if _, err := Insert(context.Background(), db, map[string]any{"name": "alice"}, Table("users")); err != nil {
+		t.Fatalf("insert with external executor: %v", err)
+	}
+	if !strings.Contains(exec.query, `INSERT INTO "users"`) {
+		t.Fatalf("expected executor query capture, got: %s", exec.query)
+	}
+}
+
+func TestUpdateExpressionAssignments(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Update(
+		context.Background(),
+		db,
+		map[string]any{"id": int64(7), "email_verified_at": "ignored"},
+		Table("app.users"),
+		PK("id"),
+		WherePK(),
+		SetExpr("email_verified_at", "COALESCE(email_verified_at, ?)", "2026-05-22T00:00:00Z"),
+		Increment("credential_version", 1),
+	)
+	if err != nil {
+		t.Fatalf("update expression assignments: %v", err)
+	}
+	if !strings.Contains(exec.query, `UPDATE "app"."users" SET "email_verified_at"=COALESCE(email_verified_at, $1), "credential_version"="credential_version" + $2 WHERE "id"=$3`) {
+		t.Fatalf("unexpected query: %s", exec.query)
+	}
+	if len(exec.args) != 3 || exec.args[0] != "2026-05-22T00:00:00Z" || exec.args[1] != 1 || exec.args[2] != int64(7) {
+		t.Fatalf("unexpected args: %#v", exec.args)
+	}
+}
+
+func TestUpdateSetColumnAssignment(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Update(
+		context.Background(),
+		db,
+		map[string]any{"id": int64(7)},
+		Table("users"),
+		PK("id"),
+		WherePK(),
+		SetColumn("updated_at", "password_changed_at"),
+	)
+	if err != nil {
+		t.Fatalf("update set column assignment: %v", err)
+	}
+	if !strings.Contains(exec.query, `SET "updated_at"="password_changed_at" WHERE "id"=$1`) {
+		t.Fatalf("unexpected query: %s", exec.query)
+	}
+	if len(exec.args) != 1 || exec.args[0] != int64(7) {
+		t.Fatalf("unexpected args: %#v", exec.args)
+	}
+}
+
+func TestUpsertExpressionAssignments(t *testing.T) {
+	db, exec := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{"id": int64(9), "name": "alice"},
+		Table("users"),
+		ConflictColumns("id"),
+		UpdateColumns("name"),
+		Increment("credential_version", 1),
+	)
+	if err != nil {
+		t.Fatalf("upsert expression assignments: %v", err)
+	}
+	if !strings.Contains(exec.query, `ON CONFLICT ("id") DO UPDATE SET "name"=EXCLUDED."name", "credential_version"="credential_version" + $3`) {
+		t.Fatalf("unexpected query: %s", exec.query)
+	}
+	if !hasArg(exec.args, int64(9)) || !hasArg(exec.args, "alice") || !hasArg(exec.args, 1) {
+		t.Fatalf("unexpected args: %#v", exec.args)
+	}
+}
+
+func TestInsertRejectsExpressionAssignments(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Insert(
+		context.Background(),
+		db,
+		map[string]any{"name": "alice"},
+		Table("users"),
+		SetRaw("updated_at", "now()"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "assignment options are not supported for Insert") {
+		t.Fatalf("expected assignment insert error, got: %v", err)
+	}
+}
+
+func TestConflictDoNothingRejectsExpressionAssignments(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, err := Upsert(
+		context.Background(),
+		db,
+		map[string]any{"id": int64(9), "name": "alice"},
+		Table("users"),
+		ConflictColumns("id"),
+		ConflictDoNothing(),
+		Increment("credential_version", 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "ConflictDoNothing cannot be combined") {
+		t.Fatalf("expected do-nothing assignment error, got: %v", err)
+	}
+}
+
+func TestInsertOnceReturningRejectsExpressionAssignments(t *testing.T) {
+	db, _ := newCaptureWriteDB(driver.PostgresDialect{})
+
+	_, _, err := InsertOnceReturning[genericWriteUser](
+		context.Background(),
+		db,
+		genericWriteUser{ID: 5, Name: "alice"},
+		WherePK(),
+		Increment("credential_version", 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "ConflictDoNothing cannot be combined") {
+		t.Fatalf("expected insert-once assignment error, got: %v", err)
 	}
 }


### PR DESCRIPTION
This PR hardens Goquent’s AI-safe ORM review boundary for v0.6.0.

Changes include:

- Harden `goquent review --require-fresh-manifest`
  - Fails when the manifest is missing, stale, or unverified
  - Supports current `--schema`, `--policy`, `--code`, and `--database-schema` inputs during review

- Add review configuration support
  - JSON config for manifest defaults, thresholds, rule overrides, and config-scoped suppressions
  - New `--fail-on-precision` gate for `partial` / `unsupported` static review

- Improve bulk write risk detection
  - Stops treating `_id` suffix columns such as `tenant_id` as primary-key-like by name alone
  - Allows manifest primary key and unique index metadata to classify narrow writes

- Make static Go review manifest-aware
  - Checks literal `Table("...")` query chains against tenant scope, soft delete, PII, required filters, and key metadata
  - Keeps unsupported dynamic patterns explicit via review precision

- Tighten `OperationSpec`
  - Rejects unresolved `value_ref` entries instead of compiling placeholder strings into query params

- Update docs and changelog for the stronger AI-safe review workflow

**Testing**
```bash
go test ./...
```

Also verified the AI-safe example review path with manifest freshness inputs.